### PR TITLE
Fix warning in dependency used in test

### DIFF
--- a/crates/contracts/bindings/Cargo.toml
+++ b/crates/contracts/bindings/Cargo.toml
@@ -8,5 +8,5 @@ rust-version.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
-[dependencies]
+[dev-dependencies]
 ethers.workspace = true

--- a/crates/contracts/bindings/src/generate_bindings.rs
+++ b/crates/contracts/bindings/src/generate_bindings.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod tests {
-
     use ethers::prelude::Abigen;
 
     /// Generate rust bindings using ethers


### PR DESCRIPTION
There was a dependency used only in a test in `contracts/bindings`, this pr moves it to `dev-dependencies`.
