### PR TITLE
reset anvil before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PHONY: reset-anvil
+
 __CONTRACTS__: ##
 
 start-anvil-chain-with-contracts-deployed: ##
@@ -14,7 +16,11 @@ stop-anvil: ##
 
 __TESTING__: ##
 
-pr: ## 
+reset-anvil:
+	$(MAKE) stop-anvil
+	docker rm anvil
+
+pr: reset-anvil ## 
 	$(MAKE) start-anvil-chain-with-contracts-deployed
 	$(MAKE) start-anvil
 	cargo test --workspace


### PR DESCRIPTION
This PR adds an small change to the Makefile to reset the anvil container before running the tests (`pr` target in the makefile).

This makes the feedback loop shorter since devs don't need to manually remove the container between runs. 

Other possible improvements:
We can just call `docker stop anvil` or `docker start anvil` instead of calling the following scripts:
- ./crates/contracts/anvil/stop-anvil.sh
- ./crates/contracts/anvil/start-anvil.sh