### PR TITLE
Remove redundant scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,27 +8,21 @@ start-anvil-chain-with-contracts-deployed: ##
 deploy-contracts-to-anvil-and-save-state: ## 
 	./crates/contracts/anvil/deploy-contracts-save-anvil-state.sh
 
-start-anvil: ##
-	./crates/contracts/anvil/start-anvil.sh
-
-stop-anvil: ##
-	./crates/contracts/anvil/stop-anvil.sh
-
 __TESTING__: ##
 
 reset-anvil:
-	$(MAKE) stop-anvil
+	docker stop anvil
 	docker rm anvil
 
 pr: reset-anvil ## 
 	$(MAKE) start-anvil-chain-with-contracts-deployed
-	$(MAKE) start-anvil
+	docker start anvil
 	cargo test --workspace
 	cargo clippy --workspace --lib --examples --tests --benches --all-features
 	cargo +nightly fmt -- --check
-	$(MAKE) stop-anvil
+	docker stop anvil
 
 fireblocks-tests:
 	$(MAKE) start-anvil-chain-with-contracts-deployed
-	$(MAKE) start-anvil
+	docker start anvil
 	cargo test --workspace --features fireblock-tests

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ deploy-contracts-to-anvil-and-save-state: ##
 __TESTING__: ##
 
 reset-anvil:
-	docker stop anvil
-	docker rm anvil
+	-docker stop anvil
+	-docker rm anvil
 
 pr: reset-anvil ## 
 	$(MAKE) start-anvil-chain-with-contracts-deployed

--- a/crates/contracts/anvil/start-anvil.sh
+++ b/crates/contracts/anvil/start-anvil.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker start anvil

--- a/crates/contracts/anvil/stop-anvil.sh
+++ b/crates/contracts/anvil/stop-anvil.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker stop anvil


### PR DESCRIPTION
This PR removes 2 scripts that were just calling single-line docker commands and replaces them with calls to the corresponding command.

It also makes the reset-anvil target run succesfully when there is no anvil container created.