### PR TITLE
Add Rewards methods

### DIFF
--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -10,6 +10,7 @@ use eigen_utils::{
             IDelegationManager::OperatorDetails,
         },
         erc20::ERC20,
+        irewardscoordinator::IRewardsCoordinator,
         strategymanager::StrategyManager,
     },
 };
@@ -24,6 +25,7 @@ pub const GAS_LIMIT_REGISTER_AS_OPERATOR_DELEGATION_MANAGER: u128 = 300000;
 pub struct ELChainWriter {
     delegation_manager: Address,
     strategy_manager: Address,
+    rewards_coordinator: Address,
     el_chain_reader: ELChainReader,
     provider: String,
     signer: String,
@@ -33,6 +35,7 @@ impl ELChainWriter {
     pub fn new(
         delegation_manager: Address,
         strategy_manager: Address,
+        rewards_coordinator: Address,
         el_chain_reader: ELChainReader,
         provider: String,
         signer: String,
@@ -40,6 +43,7 @@ impl ELChainWriter {
         Self {
             delegation_manager,
             strategy_manager,
+            rewards_coordinator,
             el_chain_reader,
             provider,
             signer,
@@ -190,6 +194,34 @@ impl ELChainWriter {
         info!("deposited {amount:?} tokens into strategy {strategy_addr:?}");
         Ok(*tx.tx_hash())
     }
+
+    /// Set a claimer for a given address on EigenLayer
+    ///
+    /// # Arguments
+    ///
+    /// * `claimer` - The address to set as the claimer
+    ///
+    /// # Returns
+    ///
+    /// * `FixedBytes<32>` - The transaction hash if successful, otherwise an error
+    ///
+    /// # Errors
+    ///
+    /// * `ElContractsError` - if the call to the contract fails
+    pub async fn set_claimer_for(
+        &self,
+        claimer: Address,
+    ) -> Result<FixedBytes<32>, ElContractsError> {
+        let provider = get_signer(&self.signer, &self.provider);
+
+        let contract_rewards_coordinator =
+            IRewardsCoordinator::new(self.rewards_coordinator, &provider);
+
+        let set_claimer_for_call = contract_rewards_coordinator.setClaimerFor(claimer);
+
+        let tx = set_claimer_for_call.send().await?;
+        Ok(*tx.tx_hash())
+    }
 }
 
 #[cfg(test)]
@@ -197,7 +229,7 @@ mod tests {
     use super::ELChainWriter;
     use crate::reader::ELChainReader;
     use alloy::providers::Provider;
-    use alloy_primitives::{Address, U256};
+    use alloy_primitives::{address, Address, U256};
     use alloy_signer_local::PrivateKeySigner;
     use anvil_constants::CONTRACTS_REGISTRY;
     use eigen_logging::get_test_logger;
@@ -205,7 +237,8 @@ mod tests {
         anvil::start_anvil_container,
         anvil_constants::{
             self, get_delegation_manager_address, get_erc20_mock_strategy,
-            get_service_manager_address, get_strategy_manager_address,
+            get_rewards_coordinator_address, get_service_manager_address,
+            get_strategy_manager_address,
         },
     };
     use eigen_types::operator::Operator;
@@ -308,10 +341,12 @@ mod tests {
         let operator_private_key =
             "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6".to_string();
         let strategy_manager = get_strategy_manager_address(http_endpoint.clone()).await;
+        let rewards_coordinator = get_rewards_coordinator_address(http_endpoint.clone()).await;
 
         let el_chain_writer = ELChainWriter::new(
             operator_addr,
             strategy_manager,
+            rewards_coordinator,
             el_chain_reader,
             http_endpoint.clone(),
             operator_private_key,
@@ -373,6 +408,38 @@ mod tests {
             .deposit_erc20_into_strategy(strategy_addr, amount)
             .await
             .unwrap();
+
+        // this sleep is needed so that we wait for the tx to be processed
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        let receipt = provider.get_transaction_receipt(tx_hash).await.unwrap();
+        assert!(receipt.unwrap().status());
+    }
+
+    #[tokio::test]
+    async fn test_set_claimer_for() {
+        // TODO: refactor test_chain_writer
+        let (_container, http_endpoint, _ws_endpoint) = start_anvil_container().await;
+        let provider = get_provider(&http_endpoint);
+
+        let (el_chain_reader, _) = setup_el_chain_reader(http_endpoint.clone()).await;
+        let operator_addr = Address::from_str("90F79bf6EB2c4f870365E785982E1f101E93b906").unwrap();
+        let operator_private_key =
+            "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6".to_string();
+        let strategy_manager = get_strategy_manager_address(http_endpoint.clone()).await;
+        let rewards_coordinator = get_rewards_coordinator_address(http_endpoint.clone()).await;
+
+        let el_chain_writer = ELChainWriter::new(
+            operator_addr,
+            strategy_manager,
+            rewards_coordinator,
+            el_chain_reader,
+            http_endpoint.clone(),
+            operator_private_key,
+        );
+
+        let claimer = address!("5eb15C0992734B5e77c888D713b4FC67b3D679A2");
+
+        let tx_hash = el_chain_writer.set_claimer_for(claimer).await.unwrap();
 
         // this sleep is needed so that we wait for the tx to be processed
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;

--- a/crates/services/operatorsinfo/src/operatorsinfo_inmemory.rs
+++ b/crates/services/operatorsinfo/src/operatorsinfo_inmemory.rs
@@ -297,7 +297,7 @@ mod tests {
     use eigen_testing_utils::anvil_constants::{
         get_avs_directory_address, get_delegation_manager_address,
         get_operator_state_retriever_address, get_registry_coordinator_address,
-        get_strategy_manager_address,
+        get_rewards_coordinator_address, get_strategy_manager_address,
     };
     use eigen_types::operator::Operator;
     use eigen_utils::get_provider;
@@ -473,6 +473,8 @@ mod tests {
             get_delegation_manager_address(http_endpoint.clone()).await;
         let avs_directory_address = get_avs_directory_address(http_endpoint.clone()).await;
         let strategy_manager_address = get_strategy_manager_address(http_endpoint.clone()).await;
+        let rewards_coordinator_address =
+            get_rewards_coordinator_address(http_endpoint.clone()).await;
         let el_chain_reader = ELChainReader::new(
             get_test_logger(),
             Address::ZERO,
@@ -485,6 +487,7 @@ mod tests {
         let el_chain_writer = ELChainWriter::new(
             delegation_manager_address,
             strategy_manager_address,
+            rewards_coordinator_address,
             el_chain_reader,
             http_endpoint.to_string(),
             pvt_key.to_string(),

--- a/examples/avsregistry-write/examples/register_operator_in_quorum_with_avs_registry_coordinator.rs
+++ b/examples/avsregistry-write/examples/register_operator_in_quorum_with_avs_registry_coordinator.rs
@@ -9,7 +9,7 @@ use eigen_crypto_bls::BlsKeyPair;
 use eigen_logging::get_test_logger;
 use eigen_testing_utils::m2_holesky_constants::{
     AVS_DIRECTORY_ADDRESS, DELEGATION_MANAGER_ADDRESS, OPERATOR_STATE_RETRIEVER,
-    REGISTRY_COORDINATOR, SLASHER_ADDRESS, STRATEGY_MANAGER_ADDRESS,
+    REGISTRY_COORDINATOR, REWARDS_COORDINATOR, SLASHER_ADDRESS, STRATEGY_MANAGER_ADDRESS,
 };
 use eigen_types::operator::Operator;
 use eyre::Result;
@@ -71,6 +71,7 @@ async fn main() -> Result<()> {
     let el_writer = ELChainWriter::new(
         DELEGATION_MANAGER_ADDRESS,
         STRATEGY_MANAGER_ADDRESS,
+        REWARDS_COORDINATOR,
         el_chain_reader,
         "https://ethereum-holesky.blockpi.network/v1/rpc/public".to_string(),
         "bead471191bea97fc3aeac36c9d74c895e8a6242602e144e43152f96219e96e8".to_string(),

--- a/examples/info-operator-service/examples/get_operator_info.rs
+++ b/examples/info-operator-service/examples/get_operator_info.rs
@@ -15,7 +15,7 @@ use eigen_testing_utils::{
     anvil_constants::{
         get_avs_directory_address, get_delegation_manager_address,
         get_operator_state_retriever_address, get_registry_coordinator_address,
-        get_strategy_manager_address,
+        get_rewards_coordinator_address, get_strategy_manager_address,
     },
 };
 use std::{
@@ -73,6 +73,7 @@ pub async fn register_operator(pvt_key: &str, bls_key: &str) {
     let delegation_manager_address = get_delegation_manager_address(http_endpoint.clone()).await;
     let avs_directory_address = get_avs_directory_address(http_endpoint.clone()).await;
     let strategy_manager_address = get_strategy_manager_address(http_endpoint.clone()).await;
+    let rewards_coordinator_address = get_rewards_coordinator_address(http_endpoint.clone()).await;
     let el_chain_reader = ELChainReader::new(
         get_test_logger(),
         Address::ZERO,
@@ -85,6 +86,7 @@ pub async fn register_operator(pvt_key: &str, bls_key: &str) {
     let el_chain_writer = ELChainWriter::new(
         delegation_manager_address,
         strategy_manager_address,
+        rewards_coordinator_address,
         el_chain_reader,
         http_endpoint.to_string(),
         pvt_key.to_string(),

--- a/testing/testing-utils/src/anvil_constants.rs
+++ b/testing/testing-utils/src/anvil_constants.rs
@@ -135,3 +135,18 @@ pub async fn get_proxy_admin(rpc_url: String) -> Address {
 
     address
 }
+
+/// Avs Directory contract address
+pub async fn get_rewards_coordinator_address(rpc_url: String) -> Address {
+    let contracts_registry = ContractsRegistry::new(CONTRACTS_REGISTRY, get_provider(&rpc_url));
+
+    let val = contracts_registry
+        .contracts("rewardsCoordinator".to_string())
+        .call()
+        .await
+        .unwrap();
+
+    let contractsReturn { _0: address } = val;
+
+    address
+}


### PR DESCRIPTION
Added this rewards methods to ElContracts ChainWriter:
- `set_claimer_for`
- `process_claim`

Still missing this methods (they are still not merged on dev branch of eigenlayer-contracts - will be merged with the [slashing PR](https://github.com/Layr-Labs/eigenlayer-contracts/pull/679)):
- `ForceDeregisterFromOperatorSets`
- `SetOperatorCommissionBips`