### PR TITLE
Fix install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ eigensdk-rs is an initiative for rust developers to build AVSs on eigenlayer.
 ## Installation
 
  ```bash
-cargo install eigen-cli
+cargo add eigensdk --features full
 ```
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ eigensdk-rs is an initiative for rust developers to build AVSs on eigenlayer.
 ## Installation
 
  ```bash
-cargo install eigensdk --features full
+cargo install eigen-cli
 ```
 
 ## Overview

--- a/crates/eigensdk/README.md
+++ b/crates/eigensdk/README.md
@@ -5,7 +5,7 @@ eigensdk-rs is an initiative for rust developers to build AVSs on eigenlayer.
 ## Installation
 
  ```bash
-cargo install eigensdk --features full
+cargo add eigensdk --features full
 ```
 
 ## Overview


### PR DESCRIPTION
Existing command must have been from before some refactor? Thinking this what you need now:

```
cargo install eigen-cli --path crates/eigen-cli/
# or direct from crates.io
cargo install eigen-cli
```