### PR TITLE
Fix TxManager, InstrumentedClient, Signer tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,7 +2355,6 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
- "alloy-node-bindings",
  "alloy-primitives",
  "alloy-rlp",
  "async-trait",
@@ -2580,7 +2579,6 @@ dependencies = [
  "alloy",
  "alloy-consensus",
  "alloy-network",
- "alloy-node-bindings",
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-signer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,11 +2258,9 @@ name = "eigen-chainio-txmanager"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-consensus",
- "alloy-node-bindings",
- "alloy-primitives",
  "eigen-logging",
  "eigen-signer",
+ "eigen-testing-utils",
  "k256",
  "once_cell",
  "reqwest 0.12.7",

--- a/crates/chainio/clients/eth/Cargo.toml
+++ b/crates/chainio/clients/eth/Cargo.toml
@@ -20,7 +20,6 @@ thiserror.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-alloy-node-bindings.workspace = true
 eigen-signer.workspace = true
 eigen-testing-utils.workspace = true
 eigen-utils.workspace = true

--- a/crates/chainio/clients/eth/src/instrumented_client.rs
+++ b/crates/chainio/clients/eth/src/instrumented_client.rs
@@ -837,9 +837,9 @@ mod tests {
     use alloy_primitives::address;
     use eigen_signer::signer::Config;
     use eigen_testing_utils::anvil::start_anvil_container;
-    use eigen_testing_utils::transaction::wait_transaction;
     use eigen_utils::get_provider;
-    use tokio;
+    use tokio::time::sleep;
+    use tokio::{self, time};
 
     #[tokio::test]
     async fn test_suggest_gas_tip_cap() {
@@ -1038,7 +1038,8 @@ mod tests {
         let tx_by_hash = instrumented_client.transaction_by_hash(tx_hash).await;
         assert!(tx_by_hash.is_ok());
 
-        wait_transaction(&rpc_url, tx_hash).await.unwrap();
+        // this sleep is needed because we have to wait since the transaction is not ready yet
+        sleep(time::Duration::from_secs(1)).await;
 
         // test transaction_receipt
         let receipt = instrumented_client.transaction_receipt(tx_hash).await;

--- a/crates/chainio/clients/eth/src/instrumented_client.rs
+++ b/crates/chainio/clients/eth/src/instrumented_client.rs
@@ -834,11 +834,11 @@ mod tests {
     use alloy::rpc::types::eth::{
         pubsub::SubscriptionResult, BlockId, BlockNumberOrTag, BlockTransactionsKind,
     };
-    use alloy_node_bindings::Anvil;
+    use alloy_primitives::address;
     use eigen_signer::signer::Config;
     use eigen_testing_utils::anvil::start_anvil_container;
+    use eigen_testing_utils::transaction::wait_transaction;
     use eigen_utils::get_provider;
-    use std::{thread, time};
     use tokio;
 
     #[tokio::test]
@@ -1006,29 +1006,23 @@ mod tests {
     /// * `transaction_in_block`
     #[tokio::test]
     async fn test_transaction_methods() {
-        let (_container, _http_endpoint, _ws_endpoint) = start_anvil_container().await;
-
-        // create a new anvil instance because otherwise it fails with "nonce too low" error.
-        let anvil = Anvil::new().try_spawn().unwrap();
-        let rpc_url: String = anvil.endpoint().parse().unwrap();
-
+        let (_container, rpc_url, _ws_endpoint) = start_anvil_container().await;
         let instrumented_client = InstrumentedClient::new(&rpc_url).await.unwrap();
 
-        let addresses = anvil.addresses().to_vec();
-        let private_key = anvil.keys().first().unwrap();
-        let to = addresses.first().unwrap();
         // build the transaction
+        let to = address!("a0Ee7A142d267C1f36714E4a8F75612F20a79720");
         let mut tx = TxLegacy {
-            to: Call(*to),
+            to: Call(to),
             value: U256::from(0),
             gas_limit: 2_000_000,
-            nonce: 0,
+            nonce: 0x69, // nonce queried from the sender account
             gas_price: 21_000_000_000,
             input: bytes!(),
             chain_id: Some(31337),
         };
 
-        let private_key_hex = hex::encode(private_key.to_bytes());
+        let private_key_hex =
+            "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string();
         let config = Config::PrivateKey(private_key_hex);
         let signer = Config::signer_from_config(config).unwrap();
         let signature = signer.sign_transaction_sync(&mut tx).unwrap();
@@ -1044,8 +1038,7 @@ mod tests {
         let tx_by_hash = instrumented_client.transaction_by_hash(tx_hash).await;
         assert!(tx_by_hash.is_ok());
 
-        // this sleep is needed because we have to wait since the transaction is not ready yet
-        thread::sleep(time::Duration::from_secs(1));
+        wait_transaction(&rpc_url, tx_hash).await.unwrap();
 
         // test transaction_receipt
         let receipt = instrumented_client.transaction_receipt(tx_hash).await;

--- a/crates/chainio/txmanager/Cargo.toml
+++ b/crates/chainio/txmanager/Cargo.toml
@@ -16,8 +16,6 @@ reqwest.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-alloy-primitives.workspace = true
-alloy-consensus.workspace = true
-alloy-node-bindings.workspace = true
+eigen-testing-utils.workspace = true
 once_cell.workspace = true
 tokio.workspace = true

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -24,7 +24,6 @@ thiserror.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-alloy-node-bindings.workspace = true
 aws-config.workspace = true
 eigen-testing-utils.workspace = true
 testcontainers.workspace = true

--- a/testing/testing-utils/src/anvil.rs
+++ b/testing/testing-utils/src/anvil.rs
@@ -6,7 +6,7 @@ use testcontainers::{
 };
 
 const ANVIL_IMAGE: &str = "ghcr.io/foundry-rs/foundry";
-const ANVIL_TAG: &str = "nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a";
+const ANVIL_TAG: &str = "latest";
 const ANVIL_STATE_PATH: &str = "./crates/contracts/anvil/contracts_deployed_anvil_state.json"; // relative path from the project root
 
 fn workspace_dir() -> PathBuf {


### PR DESCRIPTION
As foundry is no longer required, this PR updates some tests to run using an Anvil container.

Also, changed Anvil version on tests to `latest`. NOTE: this version works fine for AMD architectures but is not listed for ARM, so to run tests locally the image needs to be build manually, due to [this foundry issue](https://github.com/foundry-rs/foundry/issues/8039) 