### PR TITLE
Add retries with exponential backoff to send transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2253,6 +2267,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "async-trait",
+ "backoff",
  "eigen-logging",
  "eigen-signer",
  "eigen-testing-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ ark-serialize = "0.4.2"
 async-trait = "0.1.81"
 aws-config = "1.5.4"
 aws-sdk-kms = "1.37.0"
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 clap = { version = "4.5.11", features = ["derive"] }
 eigen-chainio-txmanager = { path = "crates/chainio/txmanager/" }
 eigen-client-avsregistry = { path = "crates/chainio/clients/avsregistry" }

--- a/crates/chainio/txmanager/Cargo.toml
+++ b/crates/chainio/txmanager/Cargo.toml
@@ -15,6 +15,7 @@ eigen-signer.workspace = true
 reqwest.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+backoff.workspace = true
 
 [dev-dependencies]
 eigen-testing-utils.workspace = true

--- a/crates/chainio/txmanager/src/simple_tx_manager.rs
+++ b/crates/chainio/txmanager/src/simple_tx_manager.rs
@@ -158,6 +158,28 @@ impl SimpleTxManager {
         SimpleTxManager::wait_for_receipt(self, pending_tx).await
     }
 
+    /// Send a transaction to the Ethereum node. It takes an unsigned/signed transaction,
+    /// sends it to the Ethereum node and waits for the receipt.
+    /// If you pass in a signed transaction it will ignore the signature
+    /// and re-sign the transaction after adding the nonce and gas limit.
+    /// If the transaction fails, it will retry sending the transaction until it gets a receipt.
+    /// If no receipt is received after `max_elapsed_time`, it will return an error.
+    ///
+    /// # Arguments
+    ///
+    /// * `tx`: The transaction to be sent.
+    /// * `initial_interval`: The initial interval duration for the backoff.
+    /// * `max_elapsed_time`: The maximum elapsed time for retrying.
+    /// * `multiplier`: The multiplier used to compute the exponential backoff.
+    ///
+    /// # Returns
+    ///
+    /// * `TransactionReceipt` The transaction receipt.
+    ///
+    /// # Errors
+    ///
+    /// * `TxManagerError` - If the transaction cannot be sent, or there is an error
+    ///   signing the transaction or estimating gas and nonce.
     pub async fn send_tx_with_retries(
         &self,
         tx: &mut TransactionRequest,

--- a/crates/chainio/txmanager/src/simple_tx_manager.rs
+++ b/crates/chainio/txmanager/src/simple_tx_manager.rs
@@ -162,7 +162,8 @@ impl SimpleTxManager {
     /// sends it to the Ethereum node and waits for the receipt.
     /// If you pass in a signed transaction it will ignore the signature
     /// and re-sign the transaction after adding the nonce and gas limit.
-    /// If the transaction fails, it will retry sending the transaction until it gets a receipt.
+    /// If the transaction fails, it will retry sending the transaction until it gets a receipt,
+    /// using an **exponential backoff** strategy.
     /// If no receipt is received after `max_elapsed_time`, it will return an error.
     ///
     /// # Arguments


### PR DESCRIPTION
Implement `send_tx_with_retries` to the Simple TxManager that sends a transaction and retries using Exponential Backoff