### PR TITLE
fix: add padding to digest to make it 32 bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,7 +2642,6 @@ dependencies = [
  "ark-bn254 0.5.0",
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
- "num-bigint 0.4.6",
  "rand",
  "rust-bls-bn254",
  "tokio",

--- a/crates/crypto/bn254/Cargo.toml
+++ b/crates/crypto/bn254/Cargo.toml
@@ -12,7 +12,6 @@ license-file.workspace = true
 ark-bn254.workspace = true
 ark-ec.workspace = true
 ark-ff.workspace = true
-num-bigint.workspace = true
 rust-bls-bn254.workspace = true
 
 

--- a/crates/crypto/bn254/src/utils.rs
+++ b/crates/crypto/bn254/src/utils.rs
@@ -18,7 +18,7 @@ pub fn map_to_curve(digest: &[u8]) -> G1Affine {
 
     // This adds padding to the digest to make it 32 bytes. Go SDK automatically does it.
     // This makes HashToCurve same for both Rust and Go SDK.
-    bytes[..digest.len()].copy_from_slice(&digest[..]);
+    bytes[..digest.len()].copy_from_slice(digest);
 
     let mut x = Fq::from_be_bytes_mod_order(&bytes);
 

--- a/crates/crypto/bn254/src/utils.rs
+++ b/crates/crypto/bn254/src/utils.rs
@@ -18,9 +18,7 @@ pub fn map_to_curve(digest: &[u8]) -> G1Affine {
 
     // This adds padding to the digest to make it 32 bytes. Go SDK automatically does it.
     // This makes HashToCurve same for both Rust and Go SDK.
-    for i in 0..digest.len() {
-        bytes[i] = digest[i];
-    }
+    bytes[..digest.len()].copy_from_slice(&digest[..]);
 
     let mut x = Fq::from_be_bytes_mod_order(&bytes);
 


### PR DESCRIPTION
This fixes the inconsistency between Go and Rust SDK

In Go SDK the message digest is automatically padded with 0. 

For ex for message "Hello, world!" the digest bytes are 
```
[72 101 108 108 111 44 32 119 111 114 108 100 33 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
```

But with current Rust implementation the bytes were
```
[72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33]
```

This creates a different `HashToCurve` mapping and hence different signature in Rust vs Go.

This following fix just iterates over digest and pads it properly to keep in 32 bytes. 