### PR TITLE
Fix BLS signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,7 +2642,6 @@ dependencies = [
  "ark-bn254 0.5.0",
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
- "num-bigint 0.4.6",
  "rand",
  "rust-bls-bn254",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,6 +2627,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "ark-std 0.4.0",
  "eigen-crypto-bn254",
+ "eigen-testing-utils",
  "eigen-utils",
  "rand",
  "serde",

--- a/crates/crypto/bls/Cargo.toml
+++ b/crates/crypto/bls/Cargo.toml
@@ -19,7 +19,9 @@ ark-std = { version = "0.4.0", default-features = false }
 serde.workspace = true
 eigen-crypto-bn254.workspace = true
 eigen-utils.workspace = true
+
 [dev-dependencies]
+eigen-testing-utils.workspace = true
 rand = "0.8.4"
 tokio = { workspace = true, features = ["full"] }
 serde_json.workspace = true

--- a/crates/crypto/bls/src/lib.rs
+++ b/crates/crypto/bls/src/lib.rs
@@ -680,20 +680,40 @@ mod tests {
 
     #[test]
     fn test_compliance() {
+        type Fp = ark_ff::Fp<ark_ff::MontBackend<ark_bn254::FqConfig, 4>, 4>;
         let message = "Hello, world!Hello, world!123456";
         let message_bytes: &[u8; 32] = message.as_bytes().try_into().unwrap();
 
         let bls_priv_key =
             "12248929636257230549931416853095037629726205319386239410403476017439825112537";
         let bls_key_pair = BlsKeyPair::new(bls_priv_key.to_string()).unwrap();
-        let public_key = bls_key_pair.public_key();
-        println!("local public_key={:?}", public_key);
         let signature = bls_key_pair.sign_message(message_bytes);
-        println!("local signature={:?}", signature);
 
-        let serialized = serde_json::to_string(&signature).expect("Failed to serialize");
+        let g1_point = signature.g1_point().g1();
+        let x = g1_point.x().unwrap();
+        let y = g1_point.y().unwrap();
 
-        println!("====================");
-        println!("{}", serialized);
+        // assert x and y with the values obtained in Go SDK
+        assert_eq!(
+            x,
+            Fp::from_bigint(
+                BigInt::from_str(
+                    "15790168376429033610067099039091292283117017641532256477437243974517959682102",
+                )
+                .unwrap()
+            )
+            .unwrap()
+        );
+
+        assert_eq!(
+            y,
+            Fp::from_bigint(
+                BigInt::from_str(
+                    "4960450323239587206117776989095741074887370703941588742100855592356200866613",
+                )
+                .unwrap()
+            )
+            .unwrap()
+        );
     }
 }

--- a/crates/crypto/bls/src/lib.rs
+++ b/crates/crypto/bls/src/lib.rs
@@ -681,7 +681,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compliance_bls_signature() {
+    fn test_bls_signature() {
         #[derive(Deserialize, Debug)]
         struct Input {
             message_bytes: String,

--- a/crates/crypto/bls/src/lib.rs
+++ b/crates/crypto/bls/src/lib.rs
@@ -690,5 +690,10 @@ mod tests {
         println!("local public_key={:?}", public_key);
         let signature = bls_key_pair.sign_message(message_bytes);
         println!("local signature={:?}", signature);
+
+        let serialized = serde_json::to_string(&signature).expect("Failed to serialize");
+
+        println!("====================");
+        println!("{}", serialized);
     }
 }

--- a/crates/crypto/bls/src/lib.rs
+++ b/crates/crypto/bls/src/lib.rs
@@ -175,7 +175,7 @@ impl BlsKeyPair {
         Signature::new(r.into_affine())
     }
 
-    pub fn sign_message(&self, message: &[u8]) -> Signature {
+    pub fn sign_message(&self, message: &[u8; 32]) -> Signature {
         let g1 = map_to_curve(message);
         let sk_int: BigInteger256 = self.priv_key.into();
         let r = g1.mul_bigint(sk_int);
@@ -676,5 +676,19 @@ mod tests {
             original_point, deserialized,
             "The deserialized point does not match the original"
         );
+    }
+
+    #[test]
+    fn test_compliance() {
+        let message = "Hello, world!Hello, world!123456";
+        let message_bytes: &[u8; 32] = message.as_bytes().try_into().unwrap();
+
+        let bls_priv_key =
+            "12248929636257230549931416853095037629726205319386239410403476017439825112537";
+        let bls_key_pair = BlsKeyPair::new(bls_priv_key.to_string()).unwrap();
+        let public_key = bls_key_pair.public_key();
+        println!("local public_key={:?}", public_key);
+        let signature = bls_key_pair.sign_message(message_bytes);
+        println!("local signature={:?}", signature);
     }
 }

--- a/crates/crypto/bls/src/lib.rs
+++ b/crates/crypto/bls/src/lib.rs
@@ -375,6 +375,8 @@ mod tests {
     use super::*;
     use ark_bn254::Fq2;
     use eigen_crypto_bn254::utils::verify_message;
+    use eigen_testing_utils::test_data::TestData;
+    type Fp = ark_ff::Fp<ark_ff::MontBackend<ark_bn254::FqConfig, 4>, 4>;
 
     #[test]
     fn test_convert_to_g1_point() {
@@ -679,14 +681,23 @@ mod tests {
     }
 
     #[test]
-    fn test_compliance() {
-        type Fp = ark_ff::Fp<ark_ff::MontBackend<ark_bn254::FqConfig, 4>, 4>;
-        let message = "Hello, world!Hello, world!123456";
-        let message_bytes: &[u8; 32] = message.as_bytes().try_into().unwrap();
+    fn test_compliance_bls_signature() {
+        #[derive(Deserialize, Debug)]
+        struct Input {
+            message_bytes: String,
+            bls_priv_key: String,
+        }
 
-        let bls_priv_key =
-            "12248929636257230549931416853095037629726205319386239410403476017439825112537";
-        let bls_key_pair = BlsKeyPair::new(bls_priv_key.to_string()).unwrap();
+        let test_data = TestData::new(Input {
+            message_bytes: "Hello, world!Hello, world!123456".to_string(),
+            bls_priv_key:
+                "12248929636257230549931416853095037629726205319386239410403476017439825112537"
+                    .to_string(),
+        });
+
+        let message_bytes: &[u8; 32] = test_data.input.message_bytes.as_bytes().try_into().unwrap();
+        let bls_priv_key = test_data.input.bls_priv_key;
+        let bls_key_pair = BlsKeyPair::new(bls_priv_key).unwrap();
         let signature = bls_key_pair.sign_message(message_bytes);
 
         let g1_point = signature.g1_point().g1();

--- a/crates/crypto/bn254/Cargo.toml
+++ b/crates/crypto/bn254/Cargo.toml
@@ -12,7 +12,6 @@ license-file.workspace = true
 ark-bn254.workspace = true
 ark-ec.workspace = true
 ark-ff.workspace = true
-num-bigint.workspace = true
 rust-bls-bn254.workspace = true
 
 

--- a/crates/crypto/bn254/src/utils.rs
+++ b/crates/crypto/bn254/src/utils.rs
@@ -15,7 +15,7 @@ pub fn map_to_curve(bytes: &[u8; 32]) -> G1Affine {
     let one = Fq::one();
     let three = Fq::from(3u64);
 
-    let mut x = Fq::from_le_bytes_mod_order(bytes);
+    let mut x = Fq::from_be_bytes_mod_order(bytes);
 
     loop {
         // y = x^3 + 3

--- a/crates/services/bls_aggregation/src/bls_agg.rs
+++ b/crates/services/bls_aggregation/src/bls_agg.rs
@@ -636,9 +636,15 @@ impl<A: AvsRegistryService + Send + Sync + Clone + 'static> BlsAggregatorService
             return Err(SignatureVerificationError::OperatorPublicKeyNotFound);
         };
 
+        let message = signed_task_response_digest
+            .task_response_digest
+            .as_slice()
+            .try_into()
+            .map_err(|_| SignatureVerificationError::IncorrectSignature)?;
+
         verify_message(
             pub_keys.g2_pub_key.g2(),
-            signed_task_response_digest.task_response_digest.as_slice(),
+            message,
             signed_task_response_digest.bls_signature.g1_point().g1(),
         )
         .then_some(())


### PR DESCRIPTION
This PR changes the signature of `sign_message` to:
``` rust
pub fn sign_message(&self, message: &[u8; 32]) -> Signature
```

and fixes the implementation of map_to_curve. There was a minor bug in the parsing of the input (endianness mismatch).