### PR TITLE
fix: typos in documentation files

### DIFF
--- a/crates/services/README.md
+++ b/crates/services/README.md
@@ -3,6 +3,6 @@
 The eigensdk provides 3 services, namely :
 
 - **OperatorInfoServiceInMemory**
-  - The `eigen-services-operatorsinfo` crate provides functionalities to manage and track operator information using an in-memory database. It supports querying past operato registrations, subscribing to new operator registration events, and retrieving operator information efficiently.
+  - The `eigen-services-operatorsinfo` crate provides functionalities to manage and track operator information using an in-memory database. It supports querying past operator registrations, subscribing to new operator registration events, and retrieving operator information efficiently.
 - `eigen-services-avsregistry`
   - The `eigen-services-avsregistry` crate is a wrapper around AvsRegistryReader.


### PR DESCRIPTION
Corrected `operato` to `operator`