### PR TITLE
Fix compatibility issue, removing slasher

### DIFF
--- a/crates/chainio/clients/elcontracts/src/reader.rs
+++ b/crates/chainio/clients/elcontracts/src/reader.rs
@@ -6,14 +6,13 @@ use eigen_utils::{
     get_provider,
     {
         avsdirectory::AVSDirectory, delegationmanager::DelegationManager, erc20::ERC20,
-        islasher::ISlasher, istrategy::IStrategy,
+        istrategy::IStrategy,
     },
 };
 
 #[derive(Debug, Clone)]
 pub struct ELChainReader {
     _logger: SharedLogger,
-    slasher: Address,
     delegation_manager: Address,
     avs_directory: Address,
     pub provider: String,
@@ -25,7 +24,6 @@ impl ELChainReader {
     /// # Arguments
     ///
     /// * `_logger` - The logger to use for logging.
-    /// * `slasher` - The address of the slasher contract.
     /// * `delegation_manager` - The address of the delegation manager contract.
     /// * `avs_directory` - The address of the avs directory contract.
     /// * `provider` - The provider to use for the RPC client.
@@ -35,22 +33,19 @@ impl ELChainReader {
     /// A new `ELChainReader` instance.
     pub fn new(
         _logger: SharedLogger,
-        slasher: Address,
         delegation_manager: Address,
         avs_directory: Address,
         provider: String,
     ) -> Self {
         ELChainReader {
             _logger,
-            slasher,
             delegation_manager,
             avs_directory,
             provider,
         }
     }
 
-    /// Builds a new `ELChainReader` instance, getting the slasher address from the delegation manager
-    /// by calling the `slasher()` function and the corresponding Contract function.
+    /// Builds a new `ELChainReader` instance
     ///
     /// # Arguments
     ///
@@ -70,22 +65,9 @@ impl ELChainReader {
         avs_directory: Address,
         client: &String,
     ) -> Result<Self, ElContractsError> {
-        let provider = get_provider(client);
-
-        let contract_delegation_manager = DelegationManager::new(delegation_manager, provider);
-
-        let slasher = contract_delegation_manager
-            .slasher()
-            .call()
-            .await
-            .map_err(ElContractsError::AlloyContractError)?;
-
-        let DelegationManager::slasherReturn { _0: slasher_addr } = slasher;
-
         Ok(Self {
             _logger,
             avs_directory,
-            slasher: slasher_addr,
             delegation_manager,
             provider: client.to_string(),
         })
@@ -206,70 +188,6 @@ impl ELChainReader {
 
         let DelegationManager::operatorSharesReturn { _0: shares } = operator_shares_in_strategy;
         Ok(shares)
-    }
-
-    /// Check if the operator is frozen
-    ///
-    /// # Arguments
-    ///
-    /// * `operator_addr` - The operator's address
-    ///
-    /// # Returns
-    ///
-    /// * `bool` - True if the operator is frozen, false otherwise
-    ///
-    /// # Errors
-    pub async fn operator_is_frozen(
-        &self,
-        operator_addr: Address,
-    ) -> Result<bool, ElContractsError> {
-        let provider = get_provider(&self.provider);
-
-        let contract_slasher = ISlasher::new(self.slasher, provider);
-
-        let operator_is_frozen = contract_slasher
-            .isFrozen(operator_addr)
-            .call()
-            .await
-            .map_err(ElContractsError::AlloyContractError)?;
-
-        let ISlasher::isFrozenReturn { _0: is_froze } = operator_is_frozen;
-        Ok(is_froze)
-    }
-
-    /// Check if the service manager can slash the operator
-    ///
-    /// # Arguments
-    ///
-    /// * `operator_addr` - The operator's address
-    /// * `service_manager_addr` - The service manager's address
-    ///
-    /// # Returns
-    ///
-    /// * `u32` - The block number until the operator can be slashed
-    ///
-    /// # Errors
-    ///
-    /// * `ElContractsError` - if the call to the contract fails    
-    pub async fn service_manager_can_slash_operator_until_block(
-        &self,
-        operator_addr: Address,
-        service_manager_addr: Address,
-    ) -> Result<u32, ElContractsError> {
-        let provider = get_provider(&self.provider);
-
-        let contract_slasher = ISlasher::new(self.slasher, provider);
-
-        let service_manager_can_slash_operator_until_block = contract_slasher
-            .contractCanSlashOperatorUntilBlock(operator_addr, service_manager_addr)
-            .call()
-            .await
-            .map_err(ElContractsError::AlloyContractError)?;
-
-        let ISlasher::contractCanSlashOperatorUntilBlockReturn { _0: can_slash } =
-            service_manager_can_slash_operator_until_block;
-
-        Ok(can_slash)
     }
 
     /// Get strategy and underlying ERC-20 token
@@ -414,12 +332,6 @@ mod tests {
     async fn build_el_chain_reader(http_endpoint: String) -> ELChainReader {
         let delegation_manager_address =
             get_delegation_manager_address(http_endpoint.clone()).await;
-        let delegation_manager_contract =
-            DelegationManager::new(delegation_manager_address, get_provider(&http_endpoint));
-        let slasher_address_return = delegation_manager_contract.slasher().call().await.unwrap();
-        let DelegationManager::slasherReturn {
-            _0: slasher_address,
-        } = slasher_address_return;
         let service_manager_address = get_service_manager_address(http_endpoint.clone()).await;
         let service_manager_contract =
             MockAvsServiceManager::new(service_manager_address, get_provider(&http_endpoint));
@@ -434,7 +346,6 @@ mod tests {
 
         ELChainReader::new(
             get_test_logger(),
-            slasher_address,
             delegation_manager_address,
             avs_directory_address,
             http_endpoint,
@@ -546,22 +457,6 @@ mod tests {
 
         let zero = U256::ZERO;
         assert!(shares > zero);
-
-        // test if operator is frozen
-        let frozen = chain_reader
-            .operator_is_frozen(operator_addr)
-            .await
-            .unwrap();
-        assert!(!frozen);
-
-        let service_manager_address = get_service_manager_address(http_endpoint).await;
-        let ret_can_slash = chain_reader
-            .service_manager_can_slash_operator_until_block(operator_addr, service_manager_address)
-            .await
-            .unwrap();
-
-        println!("ret_can_slash: {ret_can_slash}");
-        assert!(ret_can_slash == 0);
     }
 
     #[tokio::test]

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -274,7 +274,6 @@ mod tests {
     use eigen_types::operator::Operator;
     use eigen_utils::{
         contractsregistry::ContractsRegistry::{self, get_test_valuesReturn},
-        delegationmanager::DelegationManager,
         get_provider,
         irewardscoordinator::IRewardsCoordinator::{EarnerTreeMerkleLeaf, RewardsMerkleClaim},
         mockavsservicemanager::MockAvsServiceManager,
@@ -290,14 +289,6 @@ mod tests {
     async fn setup_el_chain_reader(http_endpoint: String) -> (ELChainReader, Address) {
         let delegation_manager_address =
             get_delegation_manager_address(http_endpoint.clone()).await;
-        let delegation_manager_contract = DelegationManager::new(
-            delegation_manager_address,
-            get_provider(http_endpoint.as_str()),
-        );
-        let slasher_address_return = delegation_manager_contract.slasher().call().await.unwrap();
-        let DelegationManager::slasherReturn {
-            _0: slasher_address,
-        } = slasher_address_return;
 
         let service_manager_address = get_service_manager_address(http_endpoint.clone()).await;
         let service_manager_contract = MockAvsServiceManager::new(
@@ -317,7 +308,6 @@ mod tests {
         (
             ELChainReader::new(
                 get_test_logger().clone(),
-                slasher_address,
                 delegation_manager_address,
                 avs_directory_address,
                 http_endpoint,

--- a/crates/services/operatorsinfo/src/operatorsinfo_inmemory.rs
+++ b/crates/services/operatorsinfo/src/operatorsinfo_inmemory.rs
@@ -646,7 +646,6 @@ mod tests {
             get_rewards_coordinator_address(http_endpoint.clone()).await;
         let el_chain_reader = ELChainReader::new(
             get_test_logger(),
-            Address::ZERO,
             delegation_manager_address,
             avs_directory_address,
             http_endpoint.to_string(),

--- a/examples/avsregistry-write/examples/register_operator_in_quorum_with_avs_registry_coordinator.rs
+++ b/examples/avsregistry-write/examples/register_operator_in_quorum_with_avs_registry_coordinator.rs
@@ -9,7 +9,7 @@ use eigen_crypto_bls::BlsKeyPair;
 use eigen_logging::get_test_logger;
 use eigen_testing_utils::m2_holesky_constants::{
     AVS_DIRECTORY_ADDRESS, DELEGATION_MANAGER_ADDRESS, OPERATOR_STATE_RETRIEVER,
-    REGISTRY_COORDINATOR, REWARDS_COORDINATOR, SLASHER_ADDRESS, STRATEGY_MANAGER_ADDRESS,
+    REGISTRY_COORDINATOR, REWARDS_COORDINATOR, STRATEGY_MANAGER_ADDRESS,
 };
 use eigen_types::operator::Operator;
 use eyre::Result;
@@ -62,7 +62,6 @@ async fn main() -> Result<()> {
     // A new ElChainReader instance
     let el_chain_reader = ELChainReader::new(
         get_test_logger().clone(),
-        SLASHER_ADDRESS,
         DELEGATION_MANAGER_ADDRESS,
         AVS_DIRECTORY_ADDRESS,
         "https://ethereum-holesky.blockpi.network/v1/rpc/public".to_string(),

--- a/examples/info-operator-service/examples/get_operator_info.rs
+++ b/examples/info-operator-service/examples/get_operator_info.rs
@@ -81,7 +81,6 @@ pub async fn register_operator(pvt_key: &str, bls_key: &str, http_endpoint: &str
         get_rewards_coordinator_address(http_endpoint.to_owned()).await;
     let el_chain_reader = ELChainReader::new(
         get_test_logger(),
-        Address::ZERO,
         delegation_manager_address,
         avs_directory_address,
         http_endpoint.to_owned(),


### PR DESCRIPTION
This PR fixes compatibility with the latest version of `eigenlayer-contracts`.

The change includes removing `slasher` references.