### PR TITLE
feat: add get and set `split` functions

### DIFF
--- a/crates/chainio/clients/elcontracts/src/reader.rs
+++ b/crates/chainio/clients/elcontracts/src/reader.rs
@@ -389,6 +389,39 @@ impl ELChainReader {
         Ok(claim_ret)
     }
 
+    /// Gets the split of a specific `operator` for a specific `avs`
+    ///
+    /// # Arguments
+    ///
+    /// * `operator` - The operator address
+    /// * `avs` - The AVS address
+    ///
+    /// # Returns
+    ///
+    /// * `Result<u16, ElContractsError>` - The split of the operator for the AVS, if the call is successful
+    ///
+    /// # Errors
+    ///
+    /// * `ElContractsError` - if the call to the contract fails.
+    pub async fn get_operator_avs_split(
+        &self,
+        operator: Address,
+        avs: Address,
+    ) -> Result<u16, ElContractsError> {
+        let provider = get_provider(&self.provider);
+
+        let rewards_coordinator = IRewardsCoordinator::new(self.rewards_coordinator, provider);
+
+        let operator_avs_split = rewards_coordinator
+            .getOperatorAVSSplit(operator, avs)
+            .call()
+            .await
+            .map_err(ElContractsError::AlloyContractError)?
+            ._0;
+
+        Ok(operator_avs_split)
+    }
+
     /// Get the operator's shares in a strategy
     ///
     /// # Arguments

--- a/crates/chainio/clients/elcontracts/src/reader.rs
+++ b/crates/chainio/clients/elcontracts/src/reader.rs
@@ -422,6 +422,34 @@ impl ELChainReader {
         Ok(operator_avs_split)
     }
 
+    /// Gets the split of a specific `operator` for Programmatic Incentives
+    ///
+    /// # Arguments
+    ///
+    /// * `operator` - The operator address
+    ///
+    /// # Returns
+    ///
+    /// * `Result<u16, ElContractsError>` - The split of the operator for PI, if the call is successful
+    ///
+    /// # Errors
+    ///
+    /// * `ElContractsError` - if the call to the contract fails.
+    pub async fn get_operator_pi_split(&self, operator: Address) -> Result<u16, ElContractsError> {
+        let provider = get_provider(&self.provider);
+
+        let rewards_coordinator = IRewardsCoordinator::new(self.rewards_coordinator, provider);
+
+        let operator_pi_split = rewards_coordinator
+            .getOperatorPISplit(operator)
+            .call()
+            .await
+            .map_err(ElContractsError::AlloyContractError)?
+            ._0;
+
+        Ok(operator_pi_split)
+    }
+
     /// Get the operator's shares in a strategy
     ///
     /// # Arguments

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -844,7 +844,8 @@ mod tests {
             .add_pending_admin(ANVIL_FIRST_ADDRESS, pending_admin)
             .await
             .unwrap();
-        wait_transaction(&http_endpoint, tx_hash).await.unwrap();
+        let receipt = wait_transaction(&http_endpoint, tx_hash).await.unwrap();
+        assert!(receipt.status());
 
         let is_pending_admin = el_chain_writer
             .el_chain_reader
@@ -857,7 +858,8 @@ mod tests {
             .remove_pending_admin(ANVIL_FIRST_ADDRESS, pending_admin)
             .await
             .unwrap();
-        wait_transaction(&http_endpoint, tx_hash).await.unwrap();
+        let receipt = wait_transaction(&http_endpoint, tx_hash).await.unwrap();
+        assert!(receipt.status());
 
         let is_admin = el_chain_writer
             .el_chain_reader
@@ -880,18 +882,24 @@ mod tests {
         let pending_admin_key =
             "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356";
 
-        account_writer
+        let tx_hash = account_writer
             .add_pending_admin(ANVIL_FIRST_ADDRESS, pending_admin)
             .await
             .unwrap();
 
+        let receipt = wait_transaction(&http_endpoint, tx_hash).await.unwrap();
+        assert!(receipt.status());
+
         let admin_writer =
             new_test_writer(http_endpoint.to_string(), pending_admin_key.to_string()).await;
 
-        admin_writer
+        let tx_hash = admin_writer
             .accept_admin(ANVIL_FIRST_ADDRESS)
             .await
             .unwrap();
+
+        let receipt = wait_transaction(&http_endpoint, tx_hash).await.unwrap();
+        assert!(receipt.status());
 
         let is_admin = admin_writer
             .el_chain_reader
@@ -919,14 +927,19 @@ mod tests {
             "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97";
 
         // Adding two admins and removing one. Cannot remove the last admin, so one must remain
-        el_chain_writer
+        let tx_hash = el_chain_writer
             .add_pending_admin(ANVIL_FIRST_ADDRESS, pending_admin_1)
             .await
             .unwrap();
-        el_chain_writer
+        let receipt = wait_transaction(&http_endpoint, tx_hash).await.unwrap();
+        assert!(receipt.status());
+
+        let tx_hash = el_chain_writer
             .add_pending_admin(ANVIL_FIRST_ADDRESS, pending_admin_2)
             .await
             .unwrap();
+        let receipt = wait_transaction(&http_endpoint, tx_hash).await.unwrap();
+        assert!(receipt.status());
 
         let admin_1_writer =
             new_test_writer(http_endpoint.to_string(), pending_admin_1_key.to_string()).await;
@@ -941,10 +954,13 @@ mod tests {
             .await
             .unwrap();
 
-        admin_1_writer
+        let tx_hash = admin_1_writer
             .remove_admin(ANVIL_FIRST_ADDRESS, pending_admin_2)
             .await
             .unwrap();
+
+        let receipt = wait_transaction(&http_endpoint, tx_hash).await.unwrap();
+        assert!(receipt.status());
 
         let is_admin = el_chain_writer
             .el_chain_reader

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -261,6 +261,72 @@ impl ELChainWriter {
         Ok(*tx.tx_hash())
     }
 
+    /// Sets the split of a specific `operator` for a specific `avs`
+    ///
+    /// # Arguments
+    ///
+    /// * `operator` - The operator address
+    /// * `avs` - The AVS address
+    /// * `split` - The new split of the operator for the AVS
+    ///
+    /// # Returns
+    ///
+    /// * `Result<FixedBytes<32>, ElContractsError>` - The transaction hash if the transaction is sent, otherwise an error.
+    ///
+    /// # Errors
+    ///
+    /// * `ElContractsError` - if the call to the contract fails.
+    pub async fn set_operator_avs_split(
+        &self,
+        operator: Address,
+        avs: Address,
+        split: u16,
+    ) -> Result<FixedBytes<32>, ElContractsError> {
+        let signer = get_signer(&self.signer, &self.provider);
+
+        let rewards_coordinator = IRewardsCoordinator::new(self.rewards_coordinator, signer);
+
+        let tx = rewards_coordinator
+            .setOperatorAVSSplit(operator, avs, split)
+            .send()
+            .await
+            .map_err(ElContractsError::AlloyContractError)?;
+
+        Ok(*tx.tx_hash())
+    }
+
+    /// sets the split of a specific `operator` for Programmatic Incentives
+    ///
+    /// # Arguments
+    ///
+    /// * `operator` - The operator address
+    /// * `split` - The new split of the operator for PI
+    ///
+    /// # Returns
+    ///
+    /// * `Result<FixedBytes<32>, ElContractsError>` - The transaction hash if the transaction is sent, otherwise an error.
+    ///
+    /// # Errors
+    ///
+    /// * `ElContractsError` - if the call to the contract fails.
+    pub async fn set_operator_pi_split(
+        &self,
+        operator: Address,
+        split: u16,
+    ) -> Result<FixedBytes<32>, ElContractsError> {
+        let signer = get_signer(&self.signer, &self.provider);
+
+        let rewards_coordinator = IRewardsCoordinator::new(self.rewards_coordinator, signer);
+
+        let tx = rewards_coordinator
+            .setOperatorPISplit(operator, split)
+            .send()
+            .await
+            .map_err(ElContractsError::AlloyContractError)?;
+
+        Ok(*tx.tx_hash())
+    }
+
     /// Removes permission of an appointee on a target contract, given an account address.
     ///
     /// # Arguments


### PR DESCRIPTION
This PR adds functions:
- `GetOperatorAVSSplit`
- `GetOperatorPISplit`
- `SetOperatorAVSSplit`
- `SetOperatorPISplit`