### PR TITLE
docs: add error message for `cargo test` on darwin

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ jobs:
 
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       HOLESKY_WS_URL: ${{ secrets.HOLESKY_WS_URL }}
       HOLESKY_HTTP_URL: ${{ secrets.HOLESKY_HTTP_URL }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ jobs:
 
   test:
     name: Run Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       HOLESKY_WS_URL: ${{ secrets.HOLESKY_WS_URL }}
       HOLESKY_HTTP_URL: ${{ secrets.HOLESKY_HTTP_URL }}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To test locally :-
 You need `foundry` to successfully run it.
 
 ```bash
-cargo test
+cargo test --workspace --exclude eigen-utils
 ```
 
 On Mac, you might get an error similar to:
@@ -86,13 +86,6 @@ In that case, you'll need to pull the foundry image for the `amd64` platform wit
 
 ```bash
 docker pull --platform linux/amd64/v8 ghcr.io/foundry-rs/foundry:latest
-```
-
-Sometimes the bindings fail due to containing botched doctests.
-You can exclude them from the test run with:
-
-```bash
-cargo test --workspace --exclude eigen-utils
 ```
 
 At least 1 `approving` review is required to merge the PR.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ You need `foundry` to successfully run it.
 cargo test
 ```
 
-On Mac, you might need to pull the foundry image manually specifying the platform with:
+On Mac, you might get an error similar to:
+
+```bash
+Error starting anvil container: Client(PullImage { descriptor: "ghcr.io/foundry-rs/foundry:latest", err: DockerStreamError { error: "no matching manifest for linux/arm64/v8 in the manifest list entries" } })
+```
+
+In that case, you'll need to pull the foundry image for the `amd64` platform with:
 
 ```bash
 docker pull --platform amd64 foundry-rs/foundry

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Error starting anvil container: Client(PullImage { descriptor: "ghcr.io/foundry-
 In that case, you'll need to pull the foundry image for the `amd64` platform with:
 
 ```bash
-docker pull --platform amd64 foundry-rs/foundry
+docker pull --platform linux/amd64/v8 ghcr.io/foundry-rs/foundry:latest
 ```
 
 Sometimes the bindings fail due to containing botched doctests.

--- a/crates/eigensdk/README.md
+++ b/crates/eigensdk/README.md
@@ -73,7 +73,7 @@ To test locally :-
 You need `foundry` to successfully run it.
 
 ```bash
-cargo test
+cargo test --workspace --exclude eigen-utils
 ```
 
 On Mac, you might get an error similar to:
@@ -86,13 +86,6 @@ In that case, you'll need to pull the foundry image for the `amd64` platform wit
 
 ```bash
 docker pull --platform linux/amd64/v8 ghcr.io/foundry-rs/foundry:latest
-```
-
-Sometimes the bindings fail due to containing botched doctests.
-You can exclude them from the test run with:
-
-```bash
-cargo test --workspace --exclude eigen-utils
 ```
 
 At least 1 `approving` review is required to merge the PR.

--- a/crates/eigensdk/README.md
+++ b/crates/eigensdk/README.md
@@ -76,10 +76,16 @@ You need `foundry` to successfully run it.
 cargo test
 ```
 
-On Mac, you might need to pull the foundry image manually specifying the platform with:
+On Mac, you might get an error similar to:
 
 ```bash
-docker pull --platform amd64 foundry-rs/foundry
+Error starting anvil container: Client(PullImage { descriptor: "ghcr.io/foundry-rs/foundry:latest", err: DockerStreamError { error: "no matching manifest for linux/arm64/v8 in the manifest list entries" } })
+```
+
+In that case, you'll need to pull the foundry image for the `amd64` platform with:
+
+```bash
+docker pull --platform linux/amd64/v8 ghcr.io/foundry-rs/foundry:latest
 ```
 
 Sometimes the bindings fail due to containing botched doctests.


### PR DESCRIPTION
This PR includes the error message on the readme warning and fixes the command listed.