### PR TITLE
test: fix `test_register_and_update_operator  `

### DIFF
--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -338,8 +338,7 @@ mod tests {
     /// # Arguments
     ///
     /// * `http_endpoint` - The HTTP endpoint used to send transactions.
-    /// * `private_key` - The private key used to sign transactions. If `private_key` is `None`,
-    /// then a default private key is used.
+    /// * `private_key` - The private key used to sign transactions.
     ///
     /// # Returns
     ///

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -333,6 +333,17 @@ mod tests {
         )
     }
 
+    /// Creates an instance of ELChainWriter.
+    ///
+    /// # Arguments
+    ///
+    /// * `http_endpoint` - The HTTP endpoint used to send transactions.
+    /// * `private_key` - The private key used to sign transactions. If `private_key` is `None`,
+    /// then a default private key is used.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of ELChainWriter.
     async fn new_test_writer(http_endpoint: String, private_key: Option<String>) -> ELChainWriter {
         let (el_chain_reader, _) = setup_el_chain_reader(http_endpoint.clone()).await;
         let operator_private_key = private_key.unwrap_or(


### PR DESCRIPTION
**Motivation**
The `test_register_and_update_operator` test fails since it tries to register an operator that is already registered.
This error was not caught before because it was using a wrong DelegationManager address and it was failing silently.

**Description**
This PR adds a new function `new_test_writer_with_private_key` that allows to create a test `ELChainWriter` with a specific account.
To fix the test, we simply use an unregistered account.