### PR TITLE
docs: add GitHub release changelog configuration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+Fixes #
+
+### What Changed?
+<!-- Describe the changes made in this pull request -->
+
+### Reviewer Checklist
+
+- [ ] New features are tested and documented
+- [ ] If PR introduces breaking changes, it is labeled with `breaking-change`
+- [ ] If PR introduces new features, it is labeled with `new-feature`
+- [ ] Code deprecates any old functionality before removing it

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,5 @@ Fixes #
 ### Reviewer Checklist
 
 - [ ] New features are tested and documented
-- [ ] If PR introduces breaking changes, it is labeled with `breaking-change`
-- [ ] If PR introduces new features, it is labeled with `new-feature`
+- [ ] PR has one of the `changelog-X` labels (if applies)
 - [ ] Code deprecates any old functionality before removing it

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,12 +3,31 @@ changelog:
     labels:
       - ignore-for-release
   categories:
-    - title: Breaking Changes 🛠
+    # vulnerabilities
+    - title: Security
       labels:
-        - breaking-change
-    - title: Exciting New Features 🎉
+        - changelog-security
+    # new features
+    - title: Added
       labels:
-        - new-feature
+        - changelog-added
+    # changes in existing functionality
+    - title: Changed
+      labels:
+        - changelog-changed
+    # soon-to-be removed features
+    - title: Deprecated
+      labels:
+        - changelog-deprecated
+    # now removed features
+    - title: Removed
+      labels:
+        - changelog-removed
+    # documentation was added or changed
+    - title: Documentation
+      labels:
+        - changelog-documentation
+
     - title: Other Changes
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,7 +8,7 @@ changelog:
         - breaking-change
     - title: Exciting New Features 🎉
       labels:
-        - enhancement
+        - new-feature
     - title: Other Changes
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,27 +4,27 @@ changelog:
       - ignore-for-release
   categories:
     # vulnerabilities
-    - title: Security
+    - title: Security 🔒
       labels:
         - changelog-security
     # new features
-    - title: Added
+    - title: Added 🎉
       labels:
         - changelog-added
     # changes in existing functionality
-    - title: Changed
+    - title: Changed 🛠
       labels:
         - changelog-changed
     # soon-to-be removed features
-    - title: Deprecated
+    - title: Deprecated ⚠️
       labels:
         - changelog-deprecated
     # now removed features
-    - title: Removed
+    - title: Removed 🗑
       labels:
         - changelog-removed
     # documentation was added or changed
-    - title: Documentation
+    - title: Documentation 📚
       labels:
         - changelog-documentation
 


### PR DESCRIPTION
This PR adds a GitHub release configuration, which should simplify changelog generation.