### PR TITLE
docs: add mention of updated bindings to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Each version will have a separate `Breaking Changes` section as well. To describ
   * New methods in `ELChainWriter`:
     * `set_operator_avs_split`
     * `set_operator_pi_split`
+  * Bindings updated for rewards-v2 core contracts release
 
 ### Breaking Changes 🛠
 * feat!: remove delegation manager from `ELChainWriter` by @supernovahs in https://github.com/Layr-Labs/eigensdk-rs/pull/214


### PR DESCRIPTION
Fixes #

### What Changed?

This PR fixes an oversight on the published changelog: a mention of the rewards-v2 changes updating the bindings.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
