### PR TITLE
chore: format contracts

### DIFF
--- a/crates/contracts/script/DeployMockAvs.s.sol
+++ b/crates/contracts/script/DeployMockAvs.s.sol
@@ -12,14 +12,9 @@ contract DeployMockAvs is DeployMockAvsRegistries {
     function run() public virtual {
         // The ContractsRegistry contract should always be deployed at this address on anvil
         // it's the address of the contract created at nonce 0 by the first anvil account (0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266)
-        ContractsRegistry contractsRegistry = ContractsRegistry(
-            0x5FbDB2315678afecb367f032d93F642f64180aa3
-        );
-        EigenlayerContracts
-            memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
-        MockAvsOpsAddresses memory addressConfig = _loadAvsOpsAddresses(
-            "ops_addresses"
-        );
+        ContractsRegistry contractsRegistry = ContractsRegistry(0x5FbDB2315678afecb367f032d93F642f64180aa3);
+        EigenlayerContracts memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
+        MockAvsOpsAddresses memory addressConfig = _loadAvsOpsAddresses("ops_addresses");
 
         vm.startBroadcast();
 
@@ -29,60 +24,29 @@ contract DeployMockAvs is DeployMockAvsRegistries {
         emptyContract = new EmptyContract();
         mockAvsProxyAdmin = new ProxyAdmin();
         mockAvsServiceManager = MockAvsServiceManager(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(mockAvsProxyAdmin),
-                    ""
-                )
-            )
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(mockAvsProxyAdmin), ""))
         );
-        MockAvsContracts
-            memory mockAvsContracts = _deploymockAvsRegistryContracts(
-                eigenlayerContracts,
-                addressConfig,
-                mockAvsServiceManager,
-                mockAvsServiceManagerImplementation
-            );
+        MockAvsContracts memory mockAvsContracts = _deploymockAvsRegistryContracts(
+            eigenlayerContracts, addressConfig, mockAvsServiceManager, mockAvsServiceManagerImplementation
+        );
         mockAvsServiceManagerImplementation = new MockAvsServiceManager(
-            registryCoordinator,
-            eigenlayerContracts.avsDirectory,
-            eigenlayerContracts.rewardsCoordinator
+            registryCoordinator, eigenlayerContracts.avsDirectory, eigenlayerContracts.rewardsCoordinator
         );
 
         mockAvsProxyAdmin.upgradeAndCall(
-            TransparentUpgradeableProxy(
-                payable(address(mockAvsServiceManager))
-            ),
+            TransparentUpgradeableProxy(payable(address(mockAvsServiceManager))),
             address(mockAvsServiceManagerImplementation),
             abi.encodeCall(
-                mockAvsServiceManager.initialize,
-                (addressConfig.communityMultisig, addressConfig.communityMultisig)
+                mockAvsServiceManager.initialize, (addressConfig.communityMultisig, addressConfig.communityMultisig)
             )
         );
-        require(
-            Ownable(address(mockAvsServiceManager)).owner() != address(0),
-            "Owner uninitialized"
-        );
+        require(Ownable(address(mockAvsServiceManager)).owner() != address(0), "Owner uninitialized");
 
         if (block.chainid == 31337 || block.chainid == 1337) {
-            contractsRegistry.registerContract(
-                "ProxyAdmin",
-                address(mockAvsProxyAdmin)
-            );
-            contractsRegistry.registerContract(
-                "AvsDirectory",
-                address(eigenlayerContracts.avsDirectory)
-            );
-            contractsRegistry.registerContract(
-                "eigenlayerPauserReg",
-                address(eigenlayerContracts.eigenlayerPauserReg)
-            );
-            _writeContractsToRegistry(
-                contractsRegistry,
-                eigenlayerContracts,
-                mockAvsContracts
-            );
+            contractsRegistry.registerContract("ProxyAdmin", address(mockAvsProxyAdmin));
+            contractsRegistry.registerContract("AvsDirectory", address(eigenlayerContracts.avsDirectory));
+            contractsRegistry.registerContract("eigenlayerPauserReg", address(eigenlayerContracts.eigenlayerPauserReg));
+            _writeContractsToRegistry(contractsRegistry, eigenlayerContracts, mockAvsContracts);
         }
         vm.stopBroadcast();
     }

--- a/crates/contracts/script/DeployMockAvsRegistries.s.sol
+++ b/crates/contracts/script/DeployMockAvsRegistries.s.sol
@@ -28,11 +28,7 @@ import {ContractsRegistry} from "../src/ContractsRegistry.sol";
 import "forge-std/Script.sol";
 import "forge-std/StdJson.sol";
 
-contract DeployMockAvsRegistries is
-    Script,
-    ConfigsReadWriter,
-    EigenlayerContractsParser
-{
+contract DeployMockAvsRegistries is Script, ConfigsReadWriter, EigenlayerContractsParser {
     // MockAvs contracts
     ProxyAdmin public mockAvsProxyAdmin;
     PauserRegistry public mockAvsPauserReg;
@@ -54,15 +50,14 @@ contract DeployMockAvsRegistries is
         address ejector;
     }
 
-    function _loadAvsOpsAddresses(
-        string memory opsAddressesFileName
-    ) internal view returns (MockAvsOpsAddresses memory) {
+    function _loadAvsOpsAddresses(string memory opsAddressesFileName)
+        internal
+        view
+        returns (MockAvsOpsAddresses memory)
+    {
         string memory opsAddresses = readInput(opsAddressesFileName);
         MockAvsOpsAddresses memory addressConfig;
-        addressConfig.communityMultisig = stdJson.readAddress(
-            opsAddresses,
-            ".communityMultisig"
-        );
+        addressConfig.communityMultisig = stdJson.readAddress(opsAddresses, ".communityMultisig");
         addressConfig.pauser = stdJson.readAddress(opsAddresses, ".pauser");
         addressConfig.churner = stdJson.readAddress(opsAddresses, ".churner");
         addressConfig.ejector = stdJson.readAddress(opsAddresses, ".ejector");
@@ -80,50 +75,23 @@ contract DeployMockAvsRegistries is
             address[] memory pausers = new address[](2);
             pausers[0] = addressConfig.pauser;
             pausers[1] = addressConfig.communityMultisig;
-            mockAvsPauserReg = new PauserRegistry(
-                pausers,
-                addressConfig.communityMultisig
-            );
+            mockAvsPauserReg = new PauserRegistry(pausers, addressConfig.communityMultisig);
         }
         /**
          * First, deploy upgradeable proxy contracts that **will point** to the implementations. Since the implementation contracts are
          * not yet deployed, we give these proxies an empty contract as the initial implementation, to act as if they have no code.
          */
         registryCoordinator = blsregcoord.RegistryCoordinator(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(mockAvsProxyAdmin),
-                    ""
-                )
-            )
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(mockAvsProxyAdmin), ""))
         );
         blsApkRegistry = IBLSApkRegistry(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(mockAvsProxyAdmin),
-                    ""
-                )
-            )
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(mockAvsProxyAdmin), ""))
         );
         indexRegistry = IIndexRegistry(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(mockAvsProxyAdmin),
-                    ""
-                )
-            )
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(mockAvsProxyAdmin), ""))
         );
         stakeRegistry = IStakeRegistry(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(emptyContract),
-                    address(mockAvsProxyAdmin),
-                    ""
-                )
-            )
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(mockAvsProxyAdmin), ""))
         );
 
         operatorStateRetriever = new OperatorStateRetriever();
@@ -132,29 +100,23 @@ contract DeployMockAvsRegistries is
         blsApkRegistryImplementation = new BLSApkRegistry(registryCoordinator);
 
         mockAvsProxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(blsApkRegistry))),
-            address(blsApkRegistryImplementation)
+            TransparentUpgradeableProxy(payable(address(blsApkRegistry))), address(blsApkRegistryImplementation)
         );
 
         indexRegistryImplementation = new IndexRegistry(registryCoordinator);
 
         mockAvsProxyAdmin.upgrade(
-            TransparentUpgradeableProxy(payable(address(indexRegistry))),
-            address(indexRegistryImplementation)
+            TransparentUpgradeableProxy(payable(address(indexRegistry))), address(indexRegistryImplementation)
         );
 
         {
-            stakeRegistryImplementation = new StakeRegistry(
-                registryCoordinator,
-                eigenlayerContracts.delegationManager
-            );
+            stakeRegistryImplementation = new StakeRegistry(registryCoordinator, eigenlayerContracts.delegationManager);
 
             mockAvsProxyAdmin.upgrade(
-                TransparentUpgradeableProxy(payable(address(stakeRegistry))),
-                address(stakeRegistryImplementation)
+                TransparentUpgradeableProxy(payable(address(stakeRegistry))), address(stakeRegistryImplementation)
             );
         }
-        address socketRegistry  = address(new SocketRegistry(registryCoordinator));
+        address socketRegistry = address(new SocketRegistry(registryCoordinator));
 
         registryCoordinatorImplementation = new blsregcoord.RegistryCoordinator(
             blsregcoord.IServiceManager(address(mockAvsServiceManager)),
@@ -168,26 +130,20 @@ contract DeployMockAvsRegistries is
             uint256 numQuorums = 0;
             // for each quorum to setup, we need to define
             // quorumsOperatorSetParams, quorumsMinimumStake, and quorumsStrategyParams
-            blsregcoord.RegistryCoordinator.OperatorSetParam[]
-                memory quorumsOperatorSetParams = new blsregcoord.RegistryCoordinator.OperatorSetParam[](
-                    numQuorums
-                );
+            blsregcoord.RegistryCoordinator.OperatorSetParam[] memory quorumsOperatorSetParams =
+                new blsregcoord.RegistryCoordinator.OperatorSetParam[](numQuorums);
             for (uint256 i = 0; i < numQuorums; i++) {
                 // hard code these for now
-                quorumsOperatorSetParams[i] = blsregcoord
-                    .IRegistryCoordinator
-                    .OperatorSetParam({
-                        maxOperatorCount: 10000,
-                        kickBIPsOfOperatorStake: 15000,
-                        kickBIPsOfTotalStake: 100
-                    });
+                quorumsOperatorSetParams[i] = blsregcoord.IRegistryCoordinator.OperatorSetParam({
+                    maxOperatorCount: 10000,
+                    kickBIPsOfOperatorStake: 15000,
+                    kickBIPsOfTotalStake: 100
+                });
             }
             // set to 0 for every quorum
             uint96[] memory quorumsMinimumStake = new uint96[](numQuorums);
-            IStakeRegistry.StrategyParams[][]
-                memory quorumsStrategyParams = new IStakeRegistry.StrategyParams[][](
-                    numQuorums
-                );
+            IStakeRegistry.StrategyParams[][] memory quorumsStrategyParams =
+                new IStakeRegistry.StrategyParams[][](numQuorums);
             // We don't setup up any quorums so this is commented out for now
             // (since deployedStrategyArray doesn't exist)
             // for (uint i = 0; i < numQuorums; i++) {
@@ -204,79 +160,48 @@ contract DeployMockAvsRegistries is
             //     }
             // }
             mockAvsProxyAdmin.upgradeAndCall(
-                TransparentUpgradeableProxy(
-                    payable(address(registryCoordinator))
-                ),
+                TransparentUpgradeableProxy(payable(address(registryCoordinator))),
                 address(registryCoordinatorImplementation),
                 abi.encodeCall(
                     blsregcoord.RegistryCoordinator.initialize,
-                    (addressConfig.communityMultisig,
-                    addressConfig.churner,
-                    addressConfig.ejector,
-                    IPauserRegistry(addressConfig.pauser),
-                    0, // 0 initialPausedStatus means everything unpaused
-                    quorumsOperatorSetParams,
-                    quorumsMinimumStake,
-                    quorumsStrategyParams)
+                    (
+                        addressConfig.communityMultisig,
+                        addressConfig.churner,
+                        addressConfig.ejector,
+                        IPauserRegistry(addressConfig.pauser),
+                        0, // 0 initialPausedStatus means everything unpaused
+                        quorumsOperatorSetParams,
+                        quorumsMinimumStake,
+                        quorumsStrategyParams
+                    )
                 )
             );
         }
 
-        require(
-            Ownable(address(registryCoordinator)).owner() != address(0),
-            "Owner uninitialized"
-        );
+        require(Ownable(address(registryCoordinator)).owner() != address(0), "Owner uninitialized");
 
         // WRITE JSON DATA
         {
             string memory parent_object = "parent object";
             string memory deployed_addresses = "addresses";
+            vm.serializeAddress(deployed_addresses, "proxyAdmin", address(mockAvsProxyAdmin));
+            vm.serializeAddress(deployed_addresses, "mockAvsServiceManager", address(mockAvsServiceManager));
             vm.serializeAddress(
-                deployed_addresses,
-                "proxyAdmin",
-                address(mockAvsProxyAdmin)
+                deployed_addresses, "mockAvsServiceManagerImplementation", address(mockAvsServiceManagerImplementation)
             );
+            vm.serializeAddress(deployed_addresses, "registryCoordinator", address(registryCoordinator));
             vm.serializeAddress(
-                deployed_addresses,
-                "mockAvsServiceManager",
-                address(mockAvsServiceManager)
+                deployed_addresses, "registryCoordinatorImplementation", address(registryCoordinatorImplementation)
             );
-            vm.serializeAddress(
-                deployed_addresses,
-                "mockAvsServiceManagerImplementation",
-                address(mockAvsServiceManagerImplementation)
-            );
-            vm.serializeAddress(
-                deployed_addresses,
-                "registryCoordinator",
-                address(registryCoordinator)
-            );
-            vm.serializeAddress(
-                deployed_addresses,
-                "registryCoordinatorImplementation",
-                address(registryCoordinatorImplementation)
-            );
-            string memory deployed_addresses_output = vm.serializeAddress(
-                deployed_addresses,
-                "operatorStateRetriever",
-                address(operatorStateRetriever)
-            );
+            string memory deployed_addresses_output =
+                vm.serializeAddress(deployed_addresses, "operatorStateRetriever", address(operatorStateRetriever));
 
             // serialize all the data
-            string memory finalJson = vm.serializeString(
-                parent_object,
-                deployed_addresses,
-                deployed_addresses_output
-            );
+            string memory finalJson = vm.serializeString(parent_object, deployed_addresses, deployed_addresses_output);
 
             writeOutput(finalJson, "mockavs_deployment_output");
         }
-        return
-            MockAvsContracts(
-                mockAvsServiceManager,
-                registryCoordinator,
-                operatorStateRetriever
-            );
+        return MockAvsContracts(mockAvsServiceManager, registryCoordinator, operatorStateRetriever);
     }
 
     function _writeContractsToRegistry(
@@ -284,33 +209,14 @@ contract DeployMockAvsRegistries is
         EigenlayerContracts memory eigenlayerContracts,
         MockAvsContracts memory mockAvsContracts
     ) internal {
+        contractsRegistry.registerContract("mockAvsServiceManager", address(mockAvsContracts.mockAvsServiceManager));
+        contractsRegistry.registerContract("mockAvsRegistryCoordinator", address(mockAvsContracts.registryCoordinator));
         contractsRegistry.registerContract(
-            "mockAvsServiceManager",
-            address(mockAvsContracts.mockAvsServiceManager)
+            "mockAvsOperatorStateRetriever", address(mockAvsContracts.operatorStateRetriever)
         );
-        contractsRegistry.registerContract(
-            "mockAvsRegistryCoordinator",
-            address(mockAvsContracts.registryCoordinator)
-        );
-        contractsRegistry.registerContract(
-            "mockAvsOperatorStateRetriever",
-            address(mockAvsContracts.operatorStateRetriever)
-        );
-        contractsRegistry.registerContract(
-            "delegationManager",
-            address(eigenlayerContracts.delegationManager)
-        );
-        contractsRegistry.registerContract(
-            "strategyManager",
-            address(eigenlayerContracts.strategyManager)
-        );
-        contractsRegistry.registerContract(
-            "avsDirectory",
-            address(eigenlayerContracts.avsDirectory)
-        );
-        contractsRegistry.registerContract(
-            "rewardsCoordinator",
-            address(eigenlayerContracts.rewardsCoordinator)
-        );
+        contractsRegistry.registerContract("delegationManager", address(eigenlayerContracts.delegationManager));
+        contractsRegistry.registerContract("strategyManager", address(eigenlayerContracts.strategyManager));
+        contractsRegistry.registerContract("avsDirectory", address(eigenlayerContracts.avsDirectory));
+        contractsRegistry.registerContract("rewardsCoordinator", address(eigenlayerContracts.rewardsCoordinator));
     }
 }

--- a/crates/contracts/script/DeployTokensStrategiesCreateQuorums.s.sol
+++ b/crates/contracts/script/DeployTokensStrategiesCreateQuorums.s.sol
@@ -19,24 +19,16 @@ import {console} from "forge-std/console.sol";
 import "forge-std/Script.sol";
 import "forge-std/StdJson.sol";
 
-contract DeployTokensStrategiesCreateQuorums is
-    Script,
-    EigenlayerContractsParser,
-    MockAvsContractsParser
-{
+contract DeployTokensStrategiesCreateQuorums is Script, EigenlayerContractsParser, MockAvsContractsParser {
     uint256 MINT_AMOUNT = 5_000 ether;
 
     function run() external {
         // hardcoded as first contract deployed by anvil's 0th account
         // (generated from mnemonic "test test test test test test test test test test test junk")
         // 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 (sk = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80)
-        ContractsRegistry contractsRegistry = ContractsRegistry(
-            0x5FbDB2315678afecb367f032d93F642f64180aa3
-        );
-        EigenlayerContracts
-            memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
-        MockAvsContracts
-            memory mockAvsContracts = _loadMockAvsDeployedContracts();
+        ContractsRegistry contractsRegistry = ContractsRegistry(0x5FbDB2315678afecb367f032d93F642f64180aa3);
+        EigenlayerContracts memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
+        MockAvsContracts memory mockAvsContracts = _loadMockAvsDeployedContracts();
         IStrategy strat;
         IERC20 mockToken;
         vm.startBroadcast();
@@ -48,10 +40,7 @@ contract DeployTokensStrategiesCreateQuorums is
                 eigenlayerContracts.baseStrategyImplementation,
                 eigenlayerContracts.strategyManager
             );
-            contractsRegistry.registerContract(
-                "erc20MockStrategy",
-                address(strat)
-            );
+            contractsRegistry.registerContract("erc20MockStrategy", address(strat));
         } else if (block.chainid == 17000) {
             strat = IStrategy(0x5C8b55722f421556a2AAfb7A3EA63d4c3e514312);
             /// Whitelisted stETH strat
@@ -81,10 +70,12 @@ contract DeployTokensStrategiesCreateQuorums is
                     address(eigenLayerProxyAdmin),
                     abi.encodeCall(
                         StrategyBaseTVLLimits.initialize,
-                        (1_000 ether, // maxPerDeposit
-                        1_000 ether, // maxDeposits
-                        IERC20(mockERC20),
-                        eigenLayerPauserReg)
+                        (
+                            1_000 ether, // maxPerDeposit
+                            1_000 ether, // maxDeposits
+                            IERC20(mockERC20),
+                            eigenLayerPauserReg
+                        )
                     )
                 )
             )
@@ -93,55 +84,34 @@ contract DeployTokensStrategiesCreateQuorums is
         strats[0] = erc20MockStrategy;
         bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
         thirdPartyTransfersForbiddenValues[0] = false;
-        strategyManager.addStrategiesToDepositWhitelist(
-            strats,
-            thirdPartyTransfersForbiddenValues
-        );
+        strategyManager.addStrategiesToDepositWhitelist(strats, thirdPartyTransfersForbiddenValues);
 
         // WRITE JSON DATA
         // TODO: support more than one token/strategy pair
         string memory parent_object = "parent object";
         string memory deployed_addresses = "addresses";
-        vm.serializeAddress(
-            deployed_addresses,
-            "erc20mock",
-            address(mockERC20)
-        );
-        string memory deployed_addresses_output = vm.serializeAddress(
-            deployed_addresses,
-            "erc20mockstrategy",
-            address(erc20MockStrategy)
-        );
-        string memory finalJson = vm.serializeString(
-            parent_object,
-            deployed_addresses,
-            deployed_addresses_output
-        );
+        vm.serializeAddress(deployed_addresses, "erc20mock", address(mockERC20));
+        string memory deployed_addresses_output =
+            vm.serializeAddress(deployed_addresses, "erc20mockstrategy", address(erc20MockStrategy));
+        string memory finalJson = vm.serializeString(parent_object, deployed_addresses, deployed_addresses_output);
         writeOutput(finalJson, "token_and_strategy_deployment_output");
 
         return (IERC20(mockERC20), erc20MockStrategy);
     }
 
-    function _createQuorum(
-        regcoord.RegistryCoordinator mockAvsRegCoord,
-        IStrategy strat
-    ) internal {
+    function _createQuorum(regcoord.RegistryCoordinator mockAvsRegCoord, IStrategy strat) internal {
         // for each quorum to setup, we need to define
         // quorumsOperatorSetParams, quorumsMinimumStake, and quorumsStrategyParams
-        regcoord.RegistryCoordinator.OperatorSetParam
-            memory quorumOperatorSetParams = regcoord
-                .IRegistryCoordinator
-                .OperatorSetParam({
-                    // hardcoded for now
-                    maxOperatorCount: 10000,
-                    kickBIPsOfOperatorStake: 15000,
-                    kickBIPsOfTotalStake: 100
-                });
+        regcoord.RegistryCoordinator.OperatorSetParam memory quorumOperatorSetParams = regcoord
+            .IRegistryCoordinator
+            .OperatorSetParam({
+            // hardcoded for now
+            maxOperatorCount: 10000,
+            kickBIPsOfOperatorStake: 15000,
+            kickBIPsOfTotalStake: 100
+        });
         uint96 quorumMinimumStake = 0;
-        IStakeRegistry.StrategyParams[]
-            memory quorumStrategyParams = new IStakeRegistry.StrategyParams[](
-                1
-            );
+        IStakeRegistry.StrategyParams[] memory quorumStrategyParams = new IStakeRegistry.StrategyParams[](1);
         quorumStrategyParams[0] = IStakeRegistry.StrategyParams({
             strategy: strat,
             // setting this to 1 ether since the divisor is also 1 ether
@@ -152,9 +122,7 @@ contract DeployTokensStrategiesCreateQuorums is
         });
 
         regcoord.RegistryCoordinator(address(mockAvsRegCoord)).createQuorum(
-            quorumOperatorSetParams,
-            quorumMinimumStake,
-            quorumStrategyParams
+            quorumOperatorSetParams, quorumMinimumStake, quorumStrategyParams
         );
     }
 }

--- a/crates/contracts/script/RegisterOperatorsWithEigenlayer.s.sol
+++ b/crates/contracts/script/RegisterOperatorsWithEigenlayer.s.sol
@@ -12,14 +12,12 @@ import {ContractsRegistry} from "../src/ContractsRegistry.sol";
 // This script registers a bunch of operators with eigenlayer
 // We don't register with eigencert/eigenda because events are not registered in saved anvil state, so we need to register
 // them at runtime whenver we start anvil for a test or localnet.
-contract RegisterOperators is
-    ConfigsReadWriter,
-    EigenlayerContractsParser,
-    TokenAndStrategyContractsParser
-{
+
+contract RegisterOperators is ConfigsReadWriter, EigenlayerContractsParser, TokenAndStrategyContractsParser {
     string internal mnemonic;
     uint256 internal numberOfOperators;
     ContractsRegistry contractsRegistry;
+
     function setUp() public {
         numberOfOperators = 10;
         if (block.chainid == 31337 || block.chainid == 1337) {
@@ -30,28 +28,18 @@ contract RegisterOperators is
     }
 
     function run() external {
-        contractsRegistry = ContractsRegistry(
-            0x5FbDB2315678afecb367f032d93F642f64180aa3
-        );
-        EigenlayerContracts
-            memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
-        TokenAndStrategyContracts
-            memory tokenAndStrategy = _loadTokenAndStrategyContracts();
+        contractsRegistry = ContractsRegistry(0x5FbDB2315678afecb367f032d93F642f64180aa3);
+        EigenlayerContracts memory eigenlayerContracts = _loadEigenlayerDeployedContracts();
+        TokenAndStrategyContracts memory tokenAndStrategy = _loadTokenAndStrategyContracts();
 
         address[] memory operators = new address[](numberOfOperators);
         uint256[] memory operatorsETHAmount = new uint256[](numberOfOperators);
-        uint256[] memory operatorTokenAmounts = new uint256[](
-            numberOfOperators
-        );
+        uint256[] memory operatorTokenAmounts = new uint256[](numberOfOperators);
         for (uint256 i; i < numberOfOperators; i++) {
-            (address operator, ) = deriveRememberKey(mnemonic, uint32(i));
+            (address operator,) = deriveRememberKey(mnemonic, uint32(i));
             operators[i] = operator;
             operatorsETHAmount[i] = 5 ether;
-            operatorTokenAmounts[i] = bound(
-                uint256(keccak256(bytes.concat(bytes32(uint256(i))))),
-                1 ether,
-                10 ether
-            );
+            operatorTokenAmounts[i] = bound(uint256(keccak256(bytes.concat(bytes32(uint256(i))))), 1 ether, 10 ether);
         }
         vm.startBroadcast();
 
@@ -59,11 +47,7 @@ contract RegisterOperators is
         _allocateEthOrErc20(address(0), operators, operatorsETHAmount);
 
         // Allocate tokens to operators
-        _allocateEthOrErc20(
-            address(tokenAndStrategy.token),
-            operators,
-            operatorTokenAmounts
-        );
+        _allocateEthOrErc20(address(tokenAndStrategy.token), operators, operatorTokenAmounts);
 
         vm.stopBroadcast();
 
@@ -71,43 +55,25 @@ contract RegisterOperators is
         for (uint256 i = 0; i < numberOfOperators; i++) {
             address delegationApprover = address(0); // anyone can delegate to this operator
             uint32 stakerOptOutWindowBlocks = 100;
-            string memory metadataURI = string.concat(
-                "https://coolstuff.com/operator/",
-                vm.toString(i)
-            );
+            string memory metadataURI = string.concat("https://coolstuff.com/operator/", vm.toString(i));
             (, uint256 privateKey) = deriveRememberKey(mnemonic, uint32(i));
             vm.startBroadcast(privateKey);
             if (block.chainid == 31337 || block.chainid == 1337) {
-                contractsRegistry.store_test(
-                    "test_register_operator",
-                    int(i),
-                    block.number,
-                    block.timestamp
-                );
+                contractsRegistry.store_test("test_register_operator", int256(i), block.number, block.timestamp);
             }
             eigenlayerContracts.delegationManager.registerAsOperator(
-                IDelegationManager.OperatorDetails(
-                    operators[i],
-                    delegationApprover,
-                    stakerOptOutWindowBlocks
-                ),
+                IDelegationManager.OperatorDetails(operators[i], delegationApprover, stakerOptOutWindowBlocks),
                 metadataURI
             );
             eigenlayerContracts.strategyManager.depositIntoStrategy(
-                tokenAndStrategy.strategy,
-                IERC20(tokenAndStrategy.token),
-                operatorTokenAmounts[i]
+                tokenAndStrategy.strategy, IERC20(tokenAndStrategy.token), operatorTokenAmounts[i]
             );
             vm.stopBroadcast();
         }
     }
 
     // setting token=address(0) will allocate eth
-    function _allocateEthOrErc20(
-        address token,
-        address[] memory tos,
-        uint256[] memory amounts
-    ) internal {
+    function _allocateEthOrErc20(address token, address[] memory tos, uint256[] memory amounts) internal {
         for (uint256 i = 0; i < tos.length; i++) {
             if (token == address(0)) {
                 payable(tos[i]).transfer(amounts[i]);

--- a/crates/contracts/script/parsers/ConfigsReadWriter.sol
+++ b/crates/contracts/script/parsers/ConfigsReadWriter.sol
@@ -10,45 +10,24 @@ import "forge-std/StdJson.sol";
 contract ConfigsReadWriter is Script {
     // Forge scripts best practice: https://book.getfoundry.sh/tutorials/best-practices#scripts
     // inputFileName should not contain the .json extension, we add it automatically
-    function readInput(
-        string memory inputFileName
-    ) internal view returns (string memory) {
-        string memory inputDir = string.concat(
-            vm.projectRoot(),
-            "/script/input/"
-        );
+    function readInput(string memory inputFileName) internal view returns (string memory) {
+        string memory inputDir = string.concat(vm.projectRoot(), "/script/input/");
         string memory chainDir = string.concat(vm.toString(block.chainid), "/");
         string memory file = string.concat(inputFileName, ".json");
         return vm.readFile(string.concat(inputDir, chainDir, file));
     }
 
-    function readOutput(
-        string memory outputFileName
-    ) internal view returns (string memory) {
-        string memory inputDir = string.concat(
-            vm.projectRoot(),
-            "/script/output/"
-        );
+    function readOutput(string memory outputFileName) internal view returns (string memory) {
+        string memory inputDir = string.concat(vm.projectRoot(), "/script/output/");
         string memory chainDir = string.concat(vm.toString(block.chainid), "/");
         string memory file = string.concat(outputFileName, ".json");
         return vm.readFile(string.concat(inputDir, chainDir, file));
     }
 
-    function writeOutput(
-        string memory outputJson,
-        string memory outputFileName
-    ) internal {
-        string memory outputDir = string.concat(
-            vm.projectRoot(),
-            "/script/output/"
-        );
+    function writeOutput(string memory outputJson, string memory outputFileName) internal {
+        string memory outputDir = string.concat(vm.projectRoot(), "/script/output/");
         string memory chainDir = string.concat(vm.toString(block.chainid), "/");
-        string memory outputFilePath = string.concat(
-            outputDir,
-            chainDir,
-            outputFileName,
-            ".json"
-        );
+        string memory outputFilePath = string.concat(outputDir, chainDir, outputFileName, ".json");
         vm.writeJson(outputJson, outputFilePath);
     }
 }

--- a/crates/contracts/script/parsers/EigenlayerContractsParser.sol
+++ b/crates/contracts/script/parsers/EigenlayerContractsParser.sol
@@ -26,73 +26,34 @@ struct EigenlayerContracts {
 }
 
 contract EigenlayerContractsParser is ConfigsReadWriter {
-    function _loadEigenlayerDeployedContracts()
-        internal
-        view
-        returns (EigenlayerContracts memory)
-    {
+    function _loadEigenlayerDeployedContracts() internal view returns (EigenlayerContracts memory) {
         // Eigenlayer contracts
-        string memory eigenlayerDeployedContracts = readOutput(
-            "eigenlayer_deployment_output"
-        );
-        ProxyAdmin eigenlayerProxyAdmin = ProxyAdmin(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.eigenLayerProxyAdmin"
-            )
-        );
-        PauserRegistry eigenlayerPauserReg = PauserRegistry(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.eigenLayerPauserReg"
-            )
-        );
-        IStrategyManager strategyManager = IStrategyManager(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.strategyManager"
-            )
-        );
-        IDelegationManager delegationManager = IDelegationManager(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.delegationManager"
-            )
-        );
-        IAVSDirectory avsDirectory = IAVSDirectory(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.avsDirectory"
-            )
-        );
-        ISlasher slasher = ISlasher(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.slasher"
-            )
-        );
+        string memory eigenlayerDeployedContracts = readOutput("eigenlayer_deployment_output");
+        ProxyAdmin eigenlayerProxyAdmin =
+            ProxyAdmin(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.eigenLayerProxyAdmin"));
+        PauserRegistry eigenlayerPauserReg =
+            PauserRegistry(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.eigenLayerPauserReg"));
+        IStrategyManager strategyManager =
+            IStrategyManager(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.strategyManager"));
+        IDelegationManager delegationManager =
+            IDelegationManager(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.delegationManager"));
+        IAVSDirectory avsDirectory =
+            IAVSDirectory(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.avsDirectory"));
+        ISlasher slasher = ISlasher(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.slasher"));
         StrategyBaseTVLLimits baseStrategyImplementation = StrategyBaseTVLLimits(
-                stdJson.readAddress(
-                    eigenlayerDeployedContracts,
-                    ".addresses.baseStrategyImplementation"
-                )
-            );
-        IRewardsCoordinator rewardsCoordinator = IRewardsCoordinator(
-            stdJson.readAddress(
-                eigenlayerDeployedContracts,
-                ".addresses.rewardsCoordinator"
-            )
+            stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.baseStrategyImplementation")
         );
-        return
-            EigenlayerContracts(
-                eigenlayerProxyAdmin,
-                eigenlayerPauserReg,
-                strategyManager,
-                delegationManager,
-                slasher,
-                avsDirectory,
-                rewardsCoordinator,
-                baseStrategyImplementation
-            );
+        IRewardsCoordinator rewardsCoordinator =
+            IRewardsCoordinator(stdJson.readAddress(eigenlayerDeployedContracts, ".addresses.rewardsCoordinator"));
+        return EigenlayerContracts(
+            eigenlayerProxyAdmin,
+            eigenlayerPauserReg,
+            strategyManager,
+            delegationManager,
+            slasher,
+            avsDirectory,
+            rewardsCoordinator,
+            baseStrategyImplementation
+        );
     }
 }

--- a/crates/contracts/script/parsers/MockAvsContractsParser.sol
+++ b/crates/contracts/script/parsers/MockAvsContractsParser.sol
@@ -16,51 +16,23 @@ struct MockAvsContracts {
 }
 
 contract MockAvsContractsParser is ConfigsReadWriter {
-    function _loadMockAvsDeployedContracts()
-        internal
-        view
-        returns (MockAvsContracts memory)
-    {
+    function _loadMockAvsDeployedContracts() internal view returns (MockAvsContracts memory) {
         // Eigenlayer contracts
-        string memory mockAvsDeployedContracts = readOutput(
-            "mockavs_deployment_output"
-        );
-        MockAvsServiceManager mockAvsServiceManager = MockAvsServiceManager(
-            stdJson.readAddress(
-                mockAvsDeployedContracts,
-                ".addresses.mockAvsServiceManager"
-            )
-        );
+        string memory mockAvsDeployedContracts = readOutput("mockavs_deployment_output");
+        MockAvsServiceManager mockAvsServiceManager =
+            MockAvsServiceManager(stdJson.readAddress(mockAvsDeployedContracts, ".addresses.mockAvsServiceManager"));
         require(
-            address(mockAvsServiceManager) != address(0),
-            "MockAvsContractsParser: mockAvsServiceManager address is 0"
+            address(mockAvsServiceManager) != address(0), "MockAvsContractsParser: mockAvsServiceManager address is 0"
         );
-        RegistryCoordinator registryCoordinator = RegistryCoordinator(
-            stdJson.readAddress(
-                mockAvsDeployedContracts,
-                ".addresses.registryCoordinator"
-            )
-        );
+        RegistryCoordinator registryCoordinator =
+            RegistryCoordinator(stdJson.readAddress(mockAvsDeployedContracts, ".addresses.registryCoordinator"));
+        require(address(registryCoordinator) != address(0), "MockAvsContractsParser: registryCoordinator address is 0");
+        OperatorStateRetriever operatorStateRetriever =
+            OperatorStateRetriever(stdJson.readAddress(mockAvsDeployedContracts, ".addresses.operatorStateRetriever"));
         require(
-            address(registryCoordinator) != address(0),
-            "MockAvsContractsParser: registryCoordinator address is 0"
-        );
-        OperatorStateRetriever operatorStateRetriever = OperatorStateRetriever(
-            stdJson.readAddress(
-                mockAvsDeployedContracts,
-                ".addresses.operatorStateRetriever"
-            )
-        );
-        require(
-            address(operatorStateRetriever) != address(0),
-            "MockAvsContractsParser: operatorStateRetriever address is 0"
+            address(operatorStateRetriever) != address(0), "MockAvsContractsParser: operatorStateRetriever address is 0"
         );
 
-        return
-            MockAvsContracts(
-                mockAvsServiceManager,
-                registryCoordinator,
-                operatorStateRetriever
-            );
+        return MockAvsContracts(mockAvsServiceManager, registryCoordinator, operatorStateRetriever);
     }
 }

--- a/crates/contracts/script/parsers/TokensAndStrategiesContractsParser.sol
+++ b/crates/contracts/script/parsers/TokensAndStrategiesContractsParser.sol
@@ -14,22 +14,13 @@ struct TokenAndStrategyContracts {
 
 // TODO: support more than one token/strategy pair (dee deployTokensAndStrategies script)
 contract TokenAndStrategyContractsParser is ConfigsReadWriter {
-    function _loadTokenAndStrategyContracts()
-        internal
-        view
-        returns (TokenAndStrategyContracts memory)
-    {
+    function _loadTokenAndStrategyContracts() internal view returns (TokenAndStrategyContracts memory) {
         // Token and Strategy contracts
-        string memory tokenAndStrategyConfigFile = readOutput(
-            "token_and_strategy_deployment_output"
-        );
+        string memory tokenAndStrategyConfigFile = readOutput("token_and_strategy_deployment_output");
 
-        bytes memory tokensAndStrategiesConfigsRaw = stdJson.parseRaw(
-            tokenAndStrategyConfigFile,
-            ".addresses"
-        );
-        TokenAndStrategyContracts memory tokensAndStrategiesContracts = abi
-            .decode(tokensAndStrategiesConfigsRaw, (TokenAndStrategyContracts));
+        bytes memory tokensAndStrategiesConfigsRaw = stdJson.parseRaw(tokenAndStrategyConfigFile, ".addresses");
+        TokenAndStrategyContracts memory tokensAndStrategiesContracts =
+            abi.decode(tokensAndStrategiesConfigsRaw, (TokenAndStrategyContracts));
 
         return tokensAndStrategiesContracts;
     }

--- a/crates/contracts/src/ContractsRegistry.sol
+++ b/crates/contracts/src/ContractsRegistry.sol
@@ -29,34 +29,14 @@ contract ContractsRegistry {
         contractCount++;
     }
 
-    function store_test(
-        string memory test_name,
-        int256 index,
-        uint256 timestamp,
-        uint256 block_number
-    ) public {
-        require(
-            anvil_test[keccak256(abi.encodePacked(test_name, index))]
-                .timestamp == 0
-        );
-        anvil_test[keccak256(abi.encodePacked(test_name))] = BlockAndTimestamp({
-            timestamp: timestamp,
-            block_number: block_number,
-            index: index
-        });
+    function store_test(string memory test_name, int256 index, uint256 timestamp, uint256 block_number) public {
+        require(anvil_test[keccak256(abi.encodePacked(test_name, index))].timestamp == 0);
+        anvil_test[keccak256(abi.encodePacked(test_name))] =
+            BlockAndTimestamp({timestamp: timestamp, block_number: block_number, index: index});
     }
 
-    function get_test_values(
-        string memory test_name,
-        int index
-    ) public view returns (uint256, uint256, int256) {
-        BlockAndTimestamp memory test_details = anvil_test[
-            keccak256(abi.encodePacked(test_name, index))
-        ];
-        return (
-            test_details.timestamp,
-            test_details.block_number,
-            test_details.index
-        );
+    function get_test_values(string memory test_name, int256 index) public view returns (uint256, uint256, int256) {
+        BlockAndTimestamp memory test_details = anvil_test[keccak256(abi.encodePacked(test_name, index))];
+        return (test_details.timestamp, test_details.block_number, test_details.index);
     }
 }

--- a/crates/contracts/src/MockAvsServiceManager.sol
+++ b/crates/contracts/src/MockAvsServiceManager.sol
@@ -15,16 +15,11 @@ contract MockAvsServiceManager is ServiceManagerBase, BLSSignatureChecker {
         IAVSDirectory _avsDirectory,
         IRewardsCoordinator _rewardsCoordinator
     )
-        ServiceManagerBase(
-            _avsDirectory,
-            _rewardsCoordinator,
-            _registryCoordinator,
-            _registryCoordinator.stakeRegistry()
-        )
+        ServiceManagerBase(_avsDirectory, _rewardsCoordinator, _registryCoordinator, _registryCoordinator.stakeRegistry())
         BLSSignatureChecker(_registryCoordinator)
     {}
 
-    function initialize(address _initialOwner,address _rewardsInitiator) external initializer {
-        __ServiceManagerBase_init(_initialOwner,_rewardsInitiator);
+    function initialize(address _initialOwner, address _rewardsInitiator) external initializer {
+        __ServiceManagerBase_init(_initialOwner, _rewardsInitiator);
     }
 }

--- a/crates/contracts/src/MockERC20.sol
+++ b/crates/contracts/src/MockERC20.sol
@@ -9,11 +9,7 @@ contract MockERC20 is ERC20("Mock Token", "MCK") {
     }
 
     /// WARNING: Vulnerable, bypasses allowance check. Do not use in production!
-    function transferFrom(
-        address from,
-        address to,
-        uint256 amount
-    ) public virtual override returns (bool) {
+    function transferFrom(address from, address to, uint256 amount) public virtual override returns (bool) {
         super._transfer(from, to, amount);
         return true;
     }


### PR DESCRIPTION
### What Changed?
Runs `forge fmt` to format the contracts in `crates/contracts`.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
