### PR TITLE
ci: add workflow to enforce updates to the changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,8 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
   
-    - name: Enforce PR URL in CHANGELOG.md
-      uses: dangoslen/changelog-enforcer@v3
+    - uses: dangoslen/changelog-enforcer@v3
       with:
         skipLabels: pipelines,tests,documentation
+
+    - name: Enforce PR URL in CHANGELOG.md
+      if: contains(github.event.pull_request.labels.*.name, 'changelog-')
       run: grep $PR_URL CHANGELOG.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,8 +9,7 @@ env:
 
 jobs:
   # Enforces the update of a changelog file on every pull request 
-  # We only want this for user-visible changes, so we add a few labels
-  # for which the check is skipped
+  # The update can be skipped if the pull request includes the changelog-ignore label.
   changelog:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-  
+
     - uses: dangoslen/changelog-enforcer@v3
       with:
-        skipLabels: pipelines,tests,documentation
+        skipLabels: changelog-ignore
 
     - name: Enforce PR URL in CHANGELOG.md
-      if: contains(github.event.pull_request.labels.*.name, 'changelog-')
+      if: contains(github.event.pull_request.labels.*.name, 'changelog-ignore') == false
       run: grep $PR_URL CHANGELOG.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,11 +16,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
   
-    - uses: dangoslen/changelog-enforcer@v3
-      with:
-        skipLabels: pipelines,tests,documentation
-
     - name: Enforce PR URL in CHANGELOG.md
+      uses: dangoslen/changelog-enforcer@v3
       with:
         skipLabels: pipelines,tests,documentation
       run: grep $PR_URL CHANGELOG.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,8 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 env:
-  PR_NUMBER: ${{ github.event.number }}
-  PR_URL: https://github.com/Layr-Labs/eigensdk-rs/pull/$PR_NUMBER
+  PR_URL: https://github.com/Layr-Labs/eigensdk-rs/pull/${{ github.event.number }}
 
 jobs:
   # Enforces the update of a changelog file on every pull request 
@@ -21,4 +20,3 @@ jobs:
 
     - name: Enforce PR URL in CHANGELOG.md
       run: grep $PR_URL CHANGELOG.md
-

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,5 +20,5 @@ jobs:
         skipLabels: pipelines,tests,documentation
 
     - name: Enforce PR URL in CHANGELOG.md
-    - run: grep $PR_URL CHANGELOG.md
-  
+      run: grep $PR_URL CHANGELOG.md
+

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - uses: dangoslen/changelog-enforcer@v3
       with:
@@ -22,4 +24,4 @@ jobs:
 
     - name: Enforce PR URL in CHANGELOG.md
       if: contains(github.event.pull_request.labels.*.name, 'changelog-ignore') == false
-      run: grep $PR_URL CHANGELOG.md
+      run: git diff CHANGELOG.md | grep $PR_URL CHANGELOG.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,4 +21,6 @@ jobs:
         skipLabels: pipelines,tests,documentation
 
     - name: Enforce PR URL in CHANGELOG.md
+      with:
+        skipLabels: pipelines,tests,documentation
       run: grep $PR_URL CHANGELOG.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,7 +9,8 @@ env:
 
 jobs:
   # Enforces the update of a changelog file on every pull request 
-  # The update can be skipped if the pull request includes the changelog-ignore label.
+  # The update in the changelog can be skipped if the pull request
+  # includes the `changelog-ignore` label.
   changelog:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
+env:
+  PR_NUMBER: ${{ github.event.number }}
+  PR_URL: https://github.com/Layr-Labs/eigensdk-rs/pull/$PR_NUMBER
+
 jobs:
   # Enforces the update of a changelog file on every pull request 
   # We only want this for user-visible changes, so we add a few labels
@@ -14,3 +18,7 @@ jobs:
     - uses: dangoslen/changelog-enforcer@v3
       with:
         skipLabels: pipelines,tests,documentation
+
+    - name: Enforce PR URL in CHANGELOG.md
+    - run: grep $PR_URL CHANGELOG.md
+  

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,6 +14,8 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
+  
     - uses: dangoslen/changelog-enforcer@v3
       with:
         skipLabels: pipelines,tests,documentation

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,16 @@
+name: "Pull Request Workflow"
+on:
+  merge_group:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request 
+  # We only want this for user-visible changes, so we add a few labels
+  # for which the check is skipped
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3
+      with:
+        skipLabels: pipelines,tests,documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,4 +71,4 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 ## Previous versions
 
 This changelog was introduced in-between v0.1.2 and v0.1.3.
-For changes from previous releases, you can check on our GitHub repo's releases page: [github.com/Layr-Labs/eigensdk-rs/releases](https://github.com/Layr-Labs/eigensdk-rs/releases)
+For changes from previous releases, you can check on our GitHub repo's releases page: [github.com/Layr-Labs/eigensdk-rs/releases](https://github.com/Layr-Labs/eigensdk-rs/releases) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,4 +71,4 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 ## Previous versions
 
 This changelog was introduced in-between v0.1.2 and v0.1.3.
-For changes from previous releases, you can check on our GitHub repo's releases page: [github.com/Layr-Labs/eigensdk-rs/releases](https://github.com/Layr-Labs/eigensdk-rs/releases) 
+For changes from previous releases, you can check on our GitHub repo's releases page: [github.com/Layr-Labs/eigensdk-rs/releases](https://github.com/Layr-Labs/eigensdk-rs/releases)


### PR DESCRIPTION
Fixes #238 

### What Changed?
This PR adds a workflow that enforces the `CHANGELOG.md` file to be updated on every pull request.
It is also required that the changes in the changelog include the pull request URL.
**Important:** This check is skipped if the pull request includes the `changelog-ignore` label.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
