### PR TITLE
chore: remove existing bindings when generating new ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,11 @@ bindings:
 	# Fetch submoduless
 	cd $(SDK_CONTRACTS_LOCATION) && forge install
 
+	# Empty the directories before generating the bindings
+	rm $(SDK_BINDINGS_PATH)/*
+	rm $(MIDDLEWARE_BINDINGS_PATH)/*
+	rm $(CORE_BINDINGS_PATH)/*
+
 	# Generate SDK bindings
 	cd $(SDK_CONTRACTS_LOCATION) && forge build --force --skip test --skip script
 	forge bind --alloy --skip-build --bindings-path $(SDK_BINDINGS_PATH) --overwrite \


### PR DESCRIPTION
### What Changed?
This PR changes the `make bindings` target to remove the existing bindings before generating the new ones.
This is important since it removes potentially unused bindings.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
