### PR TITLE
chore: remove alloy reexported crates from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "alloy-core",
  "alloy-eips",
  "alloy-genesis",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
@@ -303,23 +304,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-serde",
  "serde",
-]
-
-[[package]]
-name = "alloy-node-bindings"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4520cd4bc5cec20c32c98e4bc38914c7fb96bf4a712105e44da186a54e65e3ba"
-dependencies = [
- "alloy-genesis",
- "alloy-primitives",
- "k256",
- "rand",
- "serde_json",
- "tempfile",
- "thiserror 2.0.9",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -2488,10 +2472,6 @@ name = "eigen-cli"
 version = "0.1.3"
 dependencies = [
  "alloy",
- "alloy-json-rpc",
- "alloy-primitives",
- "alloy-provider",
- "alloy-transport",
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
@@ -2523,10 +2503,6 @@ name = "eigen-client-avsregistry"
 version = "0.1.3"
 dependencies = [
  "alloy",
- "alloy-node-bindings",
- "alloy-primitives",
- "alloy-signer",
- "alloy-signer-local",
  "ark-ff 0.5.0",
  "async-trait",
  "eigen-client-elcontracts",
@@ -2549,9 +2525,6 @@ name = "eigen-client-elcontracts"
 version = "0.1.3"
 dependencies = [
  "alloy",
- "alloy-primitives",
- "alloy-provider",
- "alloy-signer-local",
  "eigen-common",
  "eigen-logging",
  "eigen-testing-utils",
@@ -2569,9 +2542,6 @@ name = "eigen-client-eth"
 version = "0.1.3"
 dependencies = [
  "alloy",
- "alloy-json-rpc",
- "alloy-primitives",
- "alloy-rlp",
  "async-trait",
  "eigen-common",
  "eigen-logging",
@@ -2592,7 +2562,6 @@ name = "eigen-client-fireblocks"
 version = "0.1.3"
 dependencies = [
  "alloy",
- "alloy-primitives",
  "chrono",
  "eigen-common",
  "hex",
@@ -2612,11 +2581,7 @@ dependencies = [
 name = "eigen-common"
 version = "0.1.3"
 dependencies = [
- "alloy-provider",
- "alloy-pubsub",
- "alloy-signer-local",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy",
  "url",
 ]
 
@@ -2624,7 +2589,7 @@ dependencies = [
 name = "eigen-crypto-bls"
 version = "0.1.3"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "ark-bn254 0.5.0",
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
@@ -2666,7 +2631,7 @@ dependencies = [
 name = "eigen-metrics"
 version = "0.1.3"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "eigen-client-avsregistry",
  "eigen-client-elcontracts",
  "eigen-logging",
@@ -2685,7 +2650,7 @@ dependencies = [
 name = "eigen-metrics-collectors-economic"
 version = "0.1.3"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "eigen-client-avsregistry",
  "eigen-client-elcontracts",
  "eigen-logging",
@@ -2722,7 +2687,7 @@ dependencies = [
 name = "eigen-services-avsregistry"
 version = "0.1.3"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "ark-bn254 0.5.0",
  "ark-ec 0.5.0",
  "async-trait",
@@ -2742,9 +2707,6 @@ name = "eigen-services-blsaggregation"
 version = "0.1.3"
 dependencies = [
  "alloy",
- "alloy-node-bindings",
- "alloy-primitives",
- "alloy-provider",
  "ark-bn254 0.5.0",
  "ark-ec 0.5.0",
  "eigen-client-avsregistry",
@@ -2773,8 +2735,6 @@ name = "eigen-services-operatorsinfo"
 version = "0.1.3"
 dependencies = [
  "alloy",
- "alloy-primitives",
- "alloy-signer-local",
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
  "ark-std 0.4.0",
@@ -2801,12 +2761,6 @@ name = "eigen-signer"
 version = "0.1.3"
 dependencies = [
  "alloy",
- "alloy-network",
- "alloy-primitives",
- "alloy-rpc-client",
- "alloy-signer",
- "alloy-signer-aws",
- "alloy-signer-local",
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
@@ -2823,10 +2777,7 @@ dependencies = [
 name = "eigen-testing-utils"
 version = "0.1.3"
 dependencies = [
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-transport",
+ "alloy",
  "eigen-common",
  "eigen-utils",
  "serde",
@@ -2839,7 +2790,7 @@ dependencies = [
 name = "eigen-types"
 version = "0.1.3"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "eigen-crypto-bls",
  "ethers",
  "num-bigint 0.4.6",
@@ -3337,7 +3288,7 @@ dependencies = [
 name = "examples-anvil-utils"
 version = "0.1.3"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "eigen-client-avsregistry",
  "eigen-testing-utils",
  "eyre",
@@ -3348,7 +3299,7 @@ dependencies = [
 name = "examples-avsregistry-read"
 version = "0.1.3"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "eigen-client-avsregistry",
  "eigen-logging",
  "eigen-testing-utils",
@@ -3360,9 +3311,7 @@ dependencies = [
 name = "examples-avsregistry-write"
 version = "0.1.3"
 dependencies = [
- "alloy-primitives",
- "alloy-provider",
- "alloy-signer-local",
+ "alloy",
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",
  "ark-ff 0.5.0",
@@ -3669,10 +3618,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4004,7 +3951,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.1",
  "tower-service",
- "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -4308,9 +4254,7 @@ dependencies = [
 name = "info-operator-service"
 version = "0.1.3"
 dependencies = [
- "alloy-primitives",
- "alloy-provider",
- "alloy-signer-local",
+ "alloy",
  "eigen-client-avsregistry",
  "eigen-client-elcontracts",
  "eigen-crypto-bls",
@@ -5661,58 +5605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quinn"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash 2.1.0",
- "rustls 0.23.20",
- "socket2",
- "thiserror 2.0.9",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
-dependencies = [
- "bytes",
- "getrandom",
- "rand",
- "ring 0.17.8",
- "rustc-hash 2.1.0",
- "rustls 0.23.20",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.9",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5962,10 +5854,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5973,14 +5862,12 @@ dependencies = [
  "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.1",
  "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.7",
  "windows-registry",
 ]
 
@@ -6287,9 +6174,6 @@ name = "rustls-pki-types"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
-dependencies = [
- "web-time",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -7846,16 +7730,6 @@ name = "web-sys"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,38 +128,15 @@ parking_lot = "0.12"
 
 anvil-utils = { path = "examples/anvil-utils" }
 
-#alloy
+# alloy
 alloy = { version = "0.9", features = [
     "sol-types",
     "contract",
     "full",
     "signer-aws",
+    "rlp",
+    "json-rpc",
 ] }
-alloy-json-rpc = { version = "0.9", default-features = false }
-alloy-network = { version = "0.9", default-features = false }
-alloy-node-bindings = { version = "0.9", default-features = false }
-alloy-primitives = "0.8"
-alloy-provider = { version = "0.9", default-features = false, features = [
-    "reqwest",
-    "ws",
-] }
-alloy-pubsub = { version = "0.9", default-features = false }
-alloy-rlp = "0.3"
-alloy-rpc-client = "0.9"
-alloy-rpc-types = { version = "0.9", default-features = false, features = [
-    "eth",
-] }
-alloy-serde = { version = "0.9", default-features = false }
-alloy-signer = { version = "0.9", default-features = false }
-alloy-signer-aws = "0.9"
-alloy-signer-local = { version = "0.9", default-features = false }
-alloy-sol-types = "0.8"
-alloy-transport = { version = "0.9" }
-alloy-transport-http = { version = "0.9", features = [
-    "reqwest-rustls-tls",
-], default-features = false }
-alloy-transport-ipc = { version = "0.9", default-features = false }
-alloy-transport-ws = { version = "0.9", default-features = false }
 
 avsregistry-read = { path = "examples/avsregistry-read" }
 avsregistry-write = { path = "examples/avsregistry-write" }

--- a/crates/chainio/clients/avsregistry/Cargo.toml
+++ b/crates/chainio/clients/avsregistry/Cargo.toml
@@ -10,9 +10,6 @@ license-file.workspace = true
 
 [dependencies]
 alloy.workspace = true
-alloy-primitives.workspace = true
-alloy-signer.workspace = true
-alloy-signer-local.workspace = true
 async-trait.workspace = true
 num-bigint = "0.4.4"
 eigen-types.workspace = true
@@ -29,7 +26,6 @@ tracing.workspace = true
 workspace = true
 
 [dev-dependencies]
-alloy-node-bindings.workspace = true
 eigen-testing-utils.workspace = true
 hex = "0.4.3"
 once_cell.workspace = true

--- a/crates/chainio/clients/avsregistry/src/fake_reader.rs
+++ b/crates/chainio/clients/avsregistry/src/fake_reader.rs
@@ -1,5 +1,5 @@
 use crate::{error::AvsRegistryError, reader::AvsRegistryReader};
-use alloy_primitives::{aliases::U96, Address, Bytes, FixedBytes};
+use alloy::primitives::{aliases::U96, Address, Bytes, FixedBytes};
 use async_trait::async_trait;
 use eigen_crypto_bls::BlsKeyPair;
 use eigen_types::test::TestOperator;

--- a/crates/chainio/clients/avsregistry/src/writer.rs
+++ b/crates/chainio/clients/avsregistry/src/writer.rs
@@ -1,7 +1,7 @@
 use crate::error::AvsRegistryError;
-use alloy_primitives::{Address, Bytes, FixedBytes, TxHash, U256};
-use alloy_signer::Signer;
-use alloy_signer_local::PrivateKeySigner;
+use alloy::primitives::{Address, Bytes, FixedBytes, TxHash, U256};
+use alloy::signers::local::PrivateKeySigner;
+use alloy::signers::Signer;
 use eigen_client_elcontracts::reader::ELChainReader;
 use eigen_crypto_bls::{
     alloy_g1_point_to_g1_affine, convert_to_g1_point, convert_to_g2_point, BlsKeyPair,
@@ -331,7 +331,7 @@ impl AvsRegistryChainWriter {
 #[cfg(test)]
 mod tests {
     use super::AvsRegistryChainWriter;
-    use alloy_primitives::{Address, Bytes, FixedBytes, U256};
+    use alloy::primitives::{Address, Bytes, FixedBytes, U256};
     use eigen_crypto_bls::BlsKeyPair;
     use eigen_logging::get_test_logger;
     use eigen_testing_utils::anvil::start_anvil_container;

--- a/crates/chainio/clients/elcontracts/Cargo.toml
+++ b/crates/chainio/clients/elcontracts/Cargo.toml
@@ -10,7 +10,6 @@ license-file.workspace = true
 
 [dependencies]
 alloy.workspace = true
-alloy-primitives.workspace = true
 eigen-common.workspace = true
 eigen-logging.workspace = true
 eigen-types.workspace = true
@@ -19,9 +18,6 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-alloy.workspace = true
-alloy-provider.workspace = true
-alloy-signer-local.workspace = true
 eigen-testing-utils.workspace = true
 once_cell.workspace = true
 serial_test.workspace = true

--- a/crates/chainio/clients/elcontracts/src/reader.rs
+++ b/crates/chainio/clients/elcontracts/src/reader.rs
@@ -1,5 +1,5 @@
 use crate::error::ElContractsError;
-use alloy_primitives::{Address, FixedBytes, U256};
+use alloy::primitives::{Address, FixedBytes, U256};
 use eigen_common::get_provider;
 use eigen_logging::logger::SharedLogger;
 use eigen_types::operator::Operator;
@@ -447,9 +447,9 @@ impl ELChainReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::primitives::{address, keccak256, Address, FixedBytes, U256};
     use alloy::providers::Provider;
     use alloy::{eips::eip1898::BlockNumberOrTag::Number, rpc::types::BlockTransactionsKind};
-    use alloy_primitives::{address, keccak256, Address, FixedBytes, U256};
     use eigen_logging::get_test_logger;
     use eigen_testing_utils::{
         anvil::start_anvil_container,

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -1,6 +1,6 @@
 use crate::error::ElContractsError;
 use crate::reader::ELChainReader;
-use alloy_primitives::{Address, FixedBytes, TxHash, U256};
+use alloy::primitives::{Address, FixedBytes, TxHash, U256};
 use eigen_common::get_signer;
 pub use eigen_types::operator::Operator;
 use eigen_utils::core::irewardscoordinator::IRewardsCoordinator::{self, RewardsMerkleClaim};
@@ -328,9 +328,9 @@ impl ELChainWriter {
 mod tests {
     use super::ELChainWriter;
     use crate::reader::ELChainReader;
+    use alloy::primitives::{address, keccak256, Address, FixedBytes, U256, U8};
+    use alloy::signers::local::PrivateKeySigner;
     use alloy::{providers::Provider, sol_types::SolValue};
-    use alloy_primitives::{address, keccak256, Address, FixedBytes, U256, U8};
-    use alloy_signer_local::PrivateKeySigner;
     use anvil_constants::CONTRACTS_REGISTRY;
     use eigen_common::{get_provider, get_signer};
     use eigen_logging::get_test_logger;

--- a/crates/chainio/clients/eth/Cargo.toml
+++ b/crates/chainio/clients/eth/Cargo.toml
@@ -9,9 +9,6 @@ license-file.workspace = true
 
 [dependencies]
 alloy.workspace = true
-alloy-json-rpc.workspace = true
-alloy-primitives.workspace = true
-alloy-rlp.workspace = true
 async-trait.workspace = true
 eigen-logging.workspace = true
 eigen-metrics-collectors-rpc-calls.workspace = true

--- a/crates/chainio/clients/eth/src/instrumented_client.rs
+++ b/crates/chainio/clients/eth/src/instrumented_client.rs
@@ -1,7 +1,10 @@
 use crate::client::BackendClient;
 use alloy::consensus::TxEnvelope;
+use alloy::primitives::{Address, BlockHash, BlockNumber, Bytes, ChainId, B256, U256, U64};
 use alloy::providers::{Provider, ProviderBuilder, RootProvider};
 use alloy::pubsub::{PubSubFrontend, Subscription};
+use alloy::rlp::Encodable;
+use alloy::rpc::json_rpc::{RpcParam, RpcReturn};
 use alloy::rpc::types::eth::{
     Block, BlockNumberOrTag, FeeHistory, Filter, Header, Log, SyncStatus, Transaction,
     TransactionReceipt, TransactionRequest,
@@ -9,9 +12,6 @@ use alloy::rpc::types::eth::{
 use alloy::transports::http::{Client, Http};
 use alloy::transports::ws::WsConnect;
 use alloy::transports::{TransportError, TransportResult};
-use alloy_json_rpc::{RpcParam, RpcReturn};
-use alloy_primitives::{Address, BlockHash, BlockNumber, Bytes, ChainId, B256, U256, U64};
-use alloy_rlp::Encodable;
 use eigen_logging::get_test_logger;
 use eigen_metrics_collectors_rpc_calls::RpcCallsMetrics as RpcCallsCollector;
 use hex;
@@ -830,11 +830,11 @@ mod tests {
     use super::*;
     use alloy::consensus::{SignableTransaction, TxLegacy};
     use alloy::network::TxSignerSync;
+    use alloy::primitives::address;
     use alloy::primitives::{bytes, TxKind::Call, U256};
     use alloy::rpc::types::eth::{
         pubsub::SubscriptionResult, BlockId, BlockNumberOrTag, BlockTransactionsKind,
     };
-    use alloy_primitives::address;
     use eigen_common::get_provider;
     use eigen_signer::signer::Config;
     use eigen_testing_utils::anvil::start_anvil_container;

--- a/crates/chainio/clients/fireblocks/Cargo.toml
+++ b/crates/chainio/clients/fireblocks/Cargo.toml
@@ -10,7 +10,6 @@ license-file.workspace = true
 [dependencies]
 #alloy
 alloy.workspace = true
-alloy-primitives.workspace = true
 chrono = "0.4"
 
 #eigen

--- a/crates/chainio/clients/fireblocks/src/lib.rs
+++ b/crates/chainio/clients/fireblocks/src/lib.rs
@@ -14,10 +14,9 @@ pub mod list_external_accounts;
 mod list_vault_accounts;
 pub mod status;
 pub mod transaction;
+use alloy::primitives::{Address, U64};
 use alloy::providers::Provider;
 use alloy::rpc::types::transaction::TransactionReceipt;
-use alloy_primitives::Address;
-use alloy_primitives::U64;
 use client::{Client, ASSET_ID_BY_CHAIN};
 use eigen_common::get_provider;
 use error::FireBlockError;
@@ -198,7 +197,7 @@ impl FireblocksWallet {
         match fireblocks_tx.status() {
             Status::Completed => {
                 let provider = get_provider(&self.provider);
-                let hash = alloy_primitives::FixedBytes::<32>::from_str(&fireblocks_tx.tx_hash())
+                let hash = alloy::primitives::FixedBytes::<32>::from_str(&fireblocks_tx.tx_hash())
                     .map_err(|e| FireBlockError::OtherError(e.to_string()))?;
 
                 let tx_hash = provider.get_transaction_receipt(hash).await.map_err(|e| {
@@ -246,7 +245,7 @@ mod tests {
     #[cfg(feature = "fireblock-tests")]
     use crate::FireblocksWallet;
     #[cfg(feature = "fireblock-tests")]
-    use alloy_primitives::address;
+    use alloy::primitives::address;
     #[cfg(feature = "fireblock-tests")]
     use std::env;
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -8,9 +8,5 @@ description = "Common functions for EigenLayer SDK"
 license-file.workspace = true
 
 [dependencies]
-alloy-transport.workspace = true
-alloy-transport-http.workspace = true
-alloy-signer-local.workspace = true
-alloy-pubsub.workspace = true
-alloy-provider.workspace = true
+alloy.workspace = true
 url.workspace = true

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,14 +1,14 @@
-use alloy_provider::{
+use alloy::providers::{
     fillers::{
         BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller,
     },
     network::{Ethereum, EthereumWallet},
     Identity, ProviderBuilder, RootProvider, WsConnect,
 };
-use alloy_pubsub::PubSubFrontend;
-use alloy_signer_local::PrivateKeySigner;
-use alloy_transport::{RpcError, TransportErrorKind};
-use alloy_transport_http::{Client, Http};
+use alloy::pubsub::PubSubFrontend;
+use alloy::signers::local::PrivateKeySigner;
+use alloy::transports::http::{Client, Http};
+use alloy::transports::{RpcError, TransportErrorKind};
 use std::str::FromStr;
 use url::Url;
 
@@ -16,7 +16,7 @@ use url::Url;
 pub fn get_signer(
     key: &str,
     rpc_url: &str,
-) -> alloy_provider::fillers::FillProvider<
+) -> alloy::providers::fillers::FillProvider<
     JoinFill<
         JoinFill<
             Identity,

--- a/crates/crypto/bls/Cargo.toml
+++ b/crates/crypto/bls/Cargo.toml
@@ -14,7 +14,7 @@ ark-ff.workspace = true
 ark-serialize.workspace = true
 thiserror.workspace = true
 ark-ec.workspace = true
-alloy-primitives.workspace = true
+alloy.workspace = true
 ark-std = { version = "0.4.0", default-features = false }
 serde.workspace = true
 eigen-crypto-bn254.workspace = true

--- a/crates/crypto/bls/src/lib.rs
+++ b/crates/crypto/bls/src/lib.rs
@@ -4,7 +4,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use alloy_primitives::{B256, U256};
+use alloy::primitives::{B256, U256};
 use ark_std::str::FromStr;
 pub mod error;
 

--- a/crates/eigen-cli/Cargo.toml
+++ b/crates/eigen-cli/Cargo.toml
@@ -9,10 +9,6 @@ license-file.workspace = true
 
 [dependencies]
 alloy.workspace = true
-alloy-json-rpc.workspace = true
-alloy-primitives.workspace = true
-alloy-provider.workspace = true
-alloy-transport.workspace = true
 ark-ec.workspace = true
 ark-ff.workspace = true
 ark-serialize.workspace = true

--- a/crates/eigen-cli/src/args.rs
+++ b/crates/eigen-cli/src/args.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 use clap::{ArgGroup, Parser, Subcommand};
 use eigen_testing_utils::anvil_constants::ANVIL_HTTP_URL;
 use rust_bls_bn254::{

--- a/crates/eigen-cli/src/lib.rs
+++ b/crates/eigen-cli/src/lib.rs
@@ -194,7 +194,7 @@ mod test {
         generate::{KeyGenerator, DEFAULT_KEY_FOLDER, PASSWORD_FILE, PRIVATE_KEY_HEX_FILE},
         operator_id::derive_operator_id,
     };
-    use alloy_primitives::Address;
+    use alloy::primitives::Address;
     use eigen_testing_utils::anvil::start_anvil_container;
     use eigen_testing_utils::anvil_constants::{
         get_registry_coordinator_address, get_service_manager_address,

--- a/crates/eigen-cli/src/operator_id.rs
+++ b/crates/eigen-cli/src/operator_id.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::keccak256;
+use alloy::primitives::keccak256;
 use eigen_crypto_bls::{error::BlsError, BlsKeyPair};
 
 /// Derives an operator ID from a private key

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -14,7 +14,7 @@ metrics-exporter-prometheus.workspace = true
 metrics-util = "0.19.0"
 
 [dev-dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 eigen-metrics-collectors-economic.workspace = true 
 eigen-metrics-collectors-rpc-calls.workspace = true
 eigen-client-elcontracts.workspace = true

--- a/crates/metrics/collectors/economic/Cargo.toml
+++ b/crates/metrics/collectors/economic/Cargo.toml
@@ -8,7 +8,7 @@ description = "eigenlayer economic metrics"
 license-file.workspace = true
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 eigen-logging.workspace = true
 eigen-types.workspace = true
 eigen-client-elcontracts.workspace = true

--- a/crates/metrics/collectors/economic/src/error.rs
+++ b/crates/metrics/collectors/economic/src/error.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::ruint;
+use alloy::primitives::ruint;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/crates/metrics/collectors/economic/src/fake_collector.rs
+++ b/crates/metrics/collectors/economic/src/fake_collector.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use crate::error::CollectorMetricError;
 
-use alloy_primitives::{Address, FixedBytes, U256};
+use alloy::primitives::{Address, FixedBytes, U256};
 use eigen_client_avsregistry::reader::AvsRegistryChainReader;
 use eigen_logging::logger::SharedLogger;
 use eigen_types::operator::OperatorId;

--- a/crates/metrics/collectors/economic/src/lib.rs
+++ b/crates/metrics/collectors/economic/src/lib.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, str::FromStr};
 
 pub mod error;
 pub mod fake_collector;
-use alloy_primitives::{Address, FixedBytes, U256};
+use alloy::primitives::{Address, FixedBytes, U256};
 use eigen_client_avsregistry::reader::AvsRegistryChainReader;
 use eigen_client_elcontracts::reader::ELChainReader;
 use eigen_logging::logger::SharedLogger;
@@ -152,7 +152,7 @@ impl Collector {
 mod tests {
     use std::collections::HashMap;
 
-    use alloy_primitives::{Address, FixedBytes};
+    use alloy::primitives::{Address, FixedBytes};
     use eigen_client_avsregistry::reader::AvsRegistryChainReader;
     use eigen_logging::get_test_logger;
     use eigen_testing_utils::{

--- a/crates/metrics/src/prometheus.rs
+++ b/crates/metrics/src/prometheus.rs
@@ -20,8 +20,8 @@ mod tests {
 
     use super::*;
     use crate::eigenmetrics::EigenPerformanceMetrics;
-    use alloy_primitives::Address;
-    use alloy_primitives::FixedBytes;
+    use alloy::primitives::Address;
+    use alloy::primitives::FixedBytes;
     use eigen_client_avsregistry::reader::AvsRegistryChainReader;
     use eigen_metrics_collectors_economic::fake_collector::FakeCollector;
     use eigen_metrics_collectors_rpc_calls::RpcCallsMetrics;

--- a/crates/services/avsregistry/Cargo.toml
+++ b/crates/services/avsregistry/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 license-file.workspace = true
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 ark-bn254.workspace = true
 ark-ec.workspace = true
 async-trait.workspace = true

--- a/crates/services/avsregistry/src/chaincaller.rs
+++ b/crates/services/avsregistry/src/chaincaller.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Bytes, FixedBytes, U256};
+use alloy::primitives::{Bytes, FixedBytes, U256};
 use ark_bn254::G1Projective;
 use ark_ec::{short_weierstrass::Affine, AffineRepr, CurveGroup};
 use async_trait::async_trait;
@@ -171,7 +171,7 @@ mod tests {
 
     use super::AvsRegistryServiceChainCaller;
     use crate::AvsRegistryService;
-    use alloy_primitives::{Address, FixedBytes, U256};
+    use alloy::primitives::{Address, FixedBytes, U256};
     use eigen_client_avsregistry::fake_reader::FakeAvsRegistryReader;
     use eigen_crypto_bls::BlsKeyPair;
     use eigen_services_operatorsinfo::fake_operator_info::FakeOperatorInfoService;

--- a/crates/services/avsregistry/src/fake_avs_registry_service.rs
+++ b/crates/services/avsregistry/src/fake_avs_registry_service.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use alloy_primitives::{BlockNumber, FixedBytes, U256};
+use alloy::primitives::{BlockNumber, FixedBytes, U256};
 use ark_bn254::G1Projective;
 use ark_ec::{short_weierstrass::Affine, AffineRepr, CurveGroup};
 use async_trait::async_trait;

--- a/crates/services/avsregistry/src/lib.rs
+++ b/crates/services/avsregistry/src/lib.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 
-use alloy_primitives::FixedBytes;
+use alloy::primitives::FixedBytes;
 use async_trait::async_trait;
 use eigen_client_avsregistry::error::AvsRegistryError;
 use eigen_types::operator::{OperatorAvsState, QuorumAvsState};

--- a/crates/services/bls_aggregation/Cargo.toml
+++ b/crates/services/bls_aggregation/Cargo.toml
@@ -10,7 +10,6 @@ license-file.workspace = true
 
 [dependencies]
 alloy.workspace = true
-alloy-primitives.workspace = true
 ark-bn254.workspace = true
 ark-ec.workspace = true
 eigen-client-avsregistry.workspace = true
@@ -27,8 +26,6 @@ serde_json.workspace = true
 serde.workspace = true
 
 [dev-dependencies]
-alloy-node-bindings.workspace = true
-alloy-provider.workspace = true
 eigen-logging.workspace = true
 eigen-testing-utils.workspace = true
 eigen-utils.workspace = true

--- a/crates/services/bls_aggregation/src/bls_agg.rs
+++ b/crates/services/bls_aggregation/src/bls_agg.rs
@@ -1,6 +1,6 @@
 use super::bls_aggregation_service_error::BlsAggregationServiceError;
 use super::bls_aggregation_service_response::BlsAggregationServiceResponse;
-use alloy_primitives::{FixedBytes, Uint, U256};
+use alloy::primitives::{FixedBytes, Uint, U256};
 use ark_bn254::{G1Affine, G2Affine};
 use ark_ec::AffineRepr;
 use eigen_crypto_bls::{BlsG1Point, BlsG2Point, Signature};
@@ -786,7 +786,7 @@ impl<A: AvsRegistryService + Send + Sync + Clone + 'static> BlsAggregatorService
 #[cfg(test)]
 mod tests {
     use super::{BlsAggregationServiceError, BlsAggregationServiceResponse, BlsAggregatorService};
-    use alloy_primitives::{B256, U256};
+    use alloy::primitives::{B256, U256};
     use eigen_crypto_bls::{BlsG1Point, BlsG2Point, BlsKeyPair, Signature};
     use eigen_logging::get_test_logger;
     use eigen_services_avsregistry::fake_avs_registry_service::FakeAvsRegistryService;

--- a/crates/services/bls_aggregation/src/bls_agg_test.rs
+++ b/crates/services/bls_aggregation/src/bls_agg_test.rs
@@ -3,7 +3,7 @@ pub mod integration_test {
     use crate::bls_agg::BlsAggregatorService;
     use crate::bls_aggregation_service_response::BlsAggregationServiceResponse;
     use alloy::providers::Provider;
-    use alloy_primitives::{aliases::U96, hex, Bytes, FixedBytes, B256, U256};
+    use alloy::primitives::{aliases::U96, hex, Bytes, FixedBytes, B256, U256};
     use eigen_client_avsregistry::{
         reader::AvsRegistryChainReader, writer::AvsRegistryChainWriter,
     };

--- a/crates/services/bls_aggregation/src/bls_agg_test.rs
+++ b/crates/services/bls_aggregation/src/bls_agg_test.rs
@@ -2,8 +2,8 @@
 pub mod integration_test {
     use crate::bls_agg::BlsAggregatorService;
     use crate::bls_aggregation_service_response::BlsAggregationServiceResponse;
-    use alloy::providers::Provider;
     use alloy::primitives::{aliases::U96, hex, Bytes, FixedBytes, B256, U256};
+    use alloy::providers::Provider;
     use eigen_client_avsregistry::{
         reader::AvsRegistryChainReader, writer::AvsRegistryChainWriter,
     };

--- a/crates/services/operatorsinfo/Cargo.toml
+++ b/crates/services/operatorsinfo/Cargo.toml
@@ -11,7 +11,6 @@ license-file.workspace = true
 [dependencies]
 alloy.workspace = true
 async-trait.workspace = true
-alloy-primitives.workspace = true
 eigen-client-avsregistry.workspace = true
 eigen-common.workspace = true
 eigen-crypto-bls.workspace = true
@@ -24,9 +23,9 @@ thiserror.workspace = true
 tokio-util = "0.7.11"
 futures.workspace = true
 eyre.workspace = true
+
 [dev-dependencies]
 eigen-testing-utils.workspace = true
-alloy-signer-local.workspace = true
 eigen-logging.workspace = true
 eigen-client-elcontracts.workspace = true
 ark-bn254.workspace = true

--- a/crates/services/operatorsinfo/src/fake_operator_info.rs
+++ b/crates/services/operatorsinfo/src/fake_operator_info.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 use async_trait::async_trait;
 use eigen_crypto_bls::BlsKeyPair;
 use eigen_types::operator::{OperatorInfo, OperatorPubKeys};

--- a/crates/services/operatorsinfo/src/operator_info.rs
+++ b/crates/services/operatorsinfo/src/operator_info.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 use async_trait::async_trait;
 use eigen_types::operator::OperatorPubKeys;
 

--- a/crates/services/operatorsinfo/src/operatorsinfo_inmemory.rs
+++ b/crates/services/operatorsinfo/src/operatorsinfo_inmemory.rs
@@ -1,6 +1,6 @@
+use alloy::primitives::{Address, FixedBytes};
 use alloy::providers::Provider;
 use alloy::rpc::types::Filter;
-use alloy_primitives::{Address, FixedBytes};
 use async_trait::async_trait;
 use eigen_client_avsregistry::reader::AvsRegistryChainReader;
 use eigen_common::{get_ws_provider, NEW_PUBKEY_REGISTRATION_EVENT, OPERATOR_SOCKET_UPDATE};
@@ -155,7 +155,7 @@ impl OperatorInfoServiceInMemory {
 
                                     let mut id_map =
                                         operator_state.operator_addr_to_id.write().await;
-                                    id_map.insert(addr, alloy_primitives::FixedBytes(operator_id));
+                                    id_map.insert(addr, alloy::primitives::FixedBytes(operator_id));
                                 }
                                 let mut socket_data = operator_state.socket_dict.write().await;
                                 if let Some(socket) = socket_info {
@@ -421,8 +421,8 @@ impl OperatorInfoServiceInMemory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{address, Bytes, U256};
-    use alloy_signer_local::PrivateKeySigner;
+    use alloy::primitives::{address, Bytes, U256};
+    use alloy::signers::local::PrivateKeySigner;
     use eigen_client_avsregistry::writer::AvsRegistryChainWriter;
     use eigen_client_elcontracts::{reader::ELChainReader, writer::ELChainWriter};
     use eigen_common::get_provider;

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -9,12 +9,6 @@ license-file.workspace = true
 
 [dependencies]
 alloy.workspace =true 
-alloy-network.workspace = true
-alloy-primitives.workspace = true
-alloy-rpc-client.workspace = true
-alloy-signer.workspace = true
-alloy-signer-aws.workspace = true
-alloy-signer-local.workspace = true
 async-trait.workspace = true
 aws-sdk-kms.workspace = true
 eth-keystore.workspace = true

--- a/crates/signer/src/signer.rs
+++ b/crates/signer/src/signer.rs
@@ -69,8 +69,8 @@ mod test {
     use alloy::consensus::{SignableTransaction, TxLegacy};
     use alloy::network::{TxSigner, TxSignerSync};
     use alloy::signers::local::PrivateKeySigner;
-    use alloy_primitives::PrimitiveSignature;
-    use alloy_primitives::{address, bytes, hex_literal::hex, keccak256, Address, U256};
+    use alloy::primitives::PrimitiveSignature;
+    use alloy::primitives::{address, bytes, hex_literal::hex, keccak256, Address, U256};
     use aws_config::{BehaviorVersion, Region, SdkConfig};
     use aws_sdk_kms::{
         self,

--- a/crates/signer/src/signer.rs
+++ b/crates/signer/src/signer.rs
@@ -68,9 +68,9 @@ mod test {
     use super::Config;
     use alloy::consensus::{SignableTransaction, TxLegacy};
     use alloy::network::{TxSigner, TxSignerSync};
-    use alloy::signers::local::PrivateKeySigner;
     use alloy::primitives::PrimitiveSignature;
     use alloy::primitives::{address, bytes, hex_literal::hex, keccak256, Address, U256};
+    use alloy::signers::local::PrivateKeySigner;
     use aws_config::{BehaviorVersion, Region, SdkConfig};
     use aws_sdk_kms::{
         self,

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 license-file.workspace = true
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 eigen-crypto-bls.workspace = true
 ethers.workspace = true
 num-bigint = "0.4.4"

--- a/crates/types/src/avs.rs
+++ b/crates/types/src/avs.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::FixedBytes;
+use alloy::primitives::FixedBytes;
 use eigen_crypto_bls::Signature;
 use thiserror::Error;
 use tokio::sync::mpsc::Sender;

--- a/crates/types/src/operator.rs
+++ b/crates/types/src/operator.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{aliases::U192, Address, FixedBytes, U256};
+use alloy::primitives::{aliases::U192, Address, FixedBytes, U256};
 use eigen_crypto_bls::{convert_to_g1_point, error::BlsError, BlsG1Point, BlsG2Point, BlsKeyPair};
 use ethers::{types::U64, utils::keccak256};
 use num_bigint::BigUint;

--- a/crates/types/src/test.rs
+++ b/crates/types/src/test.rs
@@ -1,5 +1,5 @@
 use crate::operator::QuorumNum;
-use alloy_primitives::{B256, U256};
+use alloy::primitives::{B256, U256};
 use eigen_crypto_bls::BlsKeyPair;
 use std::collections::HashMap;
 

--- a/examples/anvil-utils/Cargo.toml
+++ b/examples/anvil-utils/Cargo.toml
@@ -12,7 +12,7 @@ description = "anvil utilities examples"
 workspace = true
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 
 eigen-client-avsregistry.workspace = true
 eigen-testing-utils.workspace = true

--- a/examples/avsregistry-read/Cargo.toml
+++ b/examples/avsregistry-read/Cargo.toml
@@ -12,7 +12,7 @@ description = "avsregistry read examples"
 workspace = true
 
 [dependencies]
-alloy-primitives.workspace = true
+alloy.workspace = true
 eigen-client-avsregistry.workspace = true
 eigen-logging.workspace = true
 eigen-testing-utils.workspace = true

--- a/examples/avsregistry-read/examples/get_operator_from_id.rs
+++ b/examples/avsregistry-read/examples/get_operator_from_id.rs
@@ -1,5 +1,5 @@
 //! get operator from id
-use alloy_primitives::FixedBytes;
+use alloy::primitives::FixedBytes;
 use eigen_client_avsregistry::reader::{AvsRegistryChainReader, AvsRegistryReader};
 use eigen_logging::get_test_logger;
 use eigen_testing_utils::m2_holesky_constants::{OPERATOR_STATE_RETRIEVER, REGISTRY_COORDINATOR};

--- a/examples/avsregistry-read/examples/get_operator_id.rs
+++ b/examples/avsregistry-read/examples/get_operator_id.rs
@@ -1,5 +1,5 @@
 //! get operator id
-use alloy_primitives::{address, Address};
+use alloy::primitives::{address, Address};
 use eigen_client_avsregistry::reader::AvsRegistryChainReader;
 use eigen_logging::get_test_logger;
 use eigen_testing_utils::m2_holesky_constants::{OPERATOR_STATE_RETRIEVER, REGISTRY_COORDINATOR};

--- a/examples/avsregistry-read/examples/get_operator_stake_in_quorums_of_operator_at_current_block.rs
+++ b/examples/avsregistry-read/examples/get_operator_stake_in_quorums_of_operator_at_current_block.rs
@@ -1,5 +1,5 @@
 //! get operators stake in quorums at current block
-use alloy_primitives::FixedBytes;
+use alloy::primitives::FixedBytes;
 use eigen_client_avsregistry::reader::AvsRegistryChainReader;
 use eigen_logging::get_test_logger;
 use eigen_testing_utils::m2_holesky_constants::{OPERATOR_STATE_RETRIEVER, REGISTRY_COORDINATOR};

--- a/examples/avsregistry-read/examples/get_operators_stake_in_quorums_at_block.rs
+++ b/examples/avsregistry-read/examples/get_operators_stake_in_quorums_at_block.rs
@@ -1,5 +1,5 @@
 //! get operators stake in quorums at block
-use alloy_primitives::{hex::FromHex, Bytes};
+use alloy::primitives::{hex::FromHex, Bytes};
 use eigen_client_avsregistry::reader::{AvsRegistryChainReader, AvsRegistryReader};
 use eigen_logging::get_test_logger;
 use eigen_testing_utils::m2_holesky_constants::{OPERATOR_STATE_RETRIEVER, REGISTRY_COORDINATOR};

--- a/examples/avsregistry-write/Cargo.toml
+++ b/examples/avsregistry-write/Cargo.toml
@@ -12,9 +12,7 @@ description = "avsregistry write examples"
 workspace = true
 
 [dependencies]
-alloy-primitives.workspace = true
-alloy-provider.workspace = true
-alloy-signer-local.workspace = true
+alloy.workspace = true
 ark-bn254 = "0.4.0"
 ark-ec = { version = "0.4.2", default-features = false }
 ark-ff.workspace = true

--- a/examples/avsregistry-write/examples/register_operator_in_quorum_with_avs_registry_coordinator.rs
+++ b/examples/avsregistry-write/examples/register_operator_in_quorum_with_avs_registry_coordinator.rs
@@ -1,7 +1,7 @@
 //! register operator in quorum with avs registry coordinator
-use alloy_primitives::U256;
-use alloy_primitives::{Bytes, FixedBytes};
-use alloy_signer_local::PrivateKeySigner;
+use alloy::primitives::U256;
+use alloy::primitives::{Bytes, FixedBytes};
+use alloy::signers::local::PrivateKeySigner;
 use eigen_client_avsregistry::writer::AvsRegistryChainWriter;
 use eigen_client_elcontracts::reader::ELChainReader;
 use eigen_client_elcontracts::writer::ELChainWriter;

--- a/examples/info-operator-service/Cargo.toml
+++ b/examples/info-operator-service/Cargo.toml
@@ -8,9 +8,7 @@ repository.workspace = true
 license-file.workspace = true
 
 [dependencies]
-alloy-primitives.workspace = true
-alloy-signer-local.workspace = true
-alloy-provider.workspace = true
+alloy.workspace = true
 eigen-client-avsregistry.workspace = true
 eigen-client-elcontracts.workspace = true
 eigen-crypto-bls.workspace = true

--- a/examples/info-operator-service/examples/get_operator_info.rs
+++ b/examples/info-operator-service/examples/get_operator_info.rs
@@ -1,5 +1,5 @@
-use alloy_primitives::{Address, Bytes, FixedBytes, U256};
-use alloy_signer_local::PrivateKeySigner;
+use alloy::primitives::{Address, Bytes, FixedBytes, U256};
+use alloy::signers::local::PrivateKeySigner;
 use eigen_client_avsregistry::{reader::AvsRegistryChainReader, writer::AvsRegistryChainWriter};
 use eigen_client_elcontracts::{
     reader::ELChainReader,

--- a/testing/testing-utils/Cargo.toml
+++ b/testing/testing-utils/Cargo.toml
@@ -12,10 +12,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-alloy-primitives.workspace = true
-alloy-rpc-types.workspace = true
-alloy-transport.workspace = true
-alloy-provider.workspace = true
+alloy.workspace = true
 eigen-common.workspace = true
 eigen-utils.workspace = true
 serde.workspace = true

--- a/testing/testing-utils/src/anvil_constants.rs
+++ b/testing/testing-utils/src/anvil_constants.rs
@@ -1,5 +1,5 @@
 //! Anvil utilities
-use alloy_primitives::{address, Address};
+use alloy::primitives::{address, Address};
 use eigen_utils::sdk::contractsregistry::ContractsRegistry::{self, contractsReturn};
 
 use eigen_common::get_provider;

--- a/testing/testing-utils/src/m2_holesky_constants.rs
+++ b/testing/testing-utils/src/m2_holesky_constants.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{address, Address};
+use alloy::primitives::{address, Address};
 
 /// Holesky rpc provider
 pub const HOLESKY_RPC_PROVIDER: &str = "https://ethereum-holesky-rpc.publicnode.com";

--- a/testing/testing-utils/src/mainnet_constants.rs
+++ b/testing/testing-utils/src/mainnet_constants.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{address, Address};
+use alloy::primitives::{address, Address};
 /// https://etherscan.io/address/0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A
 pub const DELEGATION_MANAGER_ADDRESS: Address =
     address!("39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A");

--- a/testing/testing-utils/src/transaction.rs
+++ b/testing/testing-utils/src/transaction.rs
@@ -1,7 +1,7 @@
-use alloy_primitives::FixedBytes;
-use alloy_provider::{PendingTransactionBuilder, PendingTransactionError, ProviderBuilder};
-use alloy_rpc_types::eth::TransactionReceipt;
-use alloy_transport::TransportErrorKind;
+use alloy::primitives::FixedBytes;
+use alloy::providers::{PendingTransactionBuilder, PendingTransactionError, ProviderBuilder};
+use alloy::rpc::types::eth::TransactionReceipt;
+use alloy::transports::TransportErrorKind;
 use url::Url;
 
 /// Wait for a transaction to finish and return its receipt.


### PR DESCRIPTION
Fixes #197 

### What Changed?
This PR introduces the following changes
* Removes all the `alloy-*` reexported crates from the workspace dependencies, leaving only `alloy`.
* Updates the workspace dependencies on every crate, removing the `alloy-*.workspace = true` imports and leaving only `alloy.workspace = true`.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
