### PR TITLE
remove homepage from testing-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 
 ### Breaking changes
 ### Removed
+* Removed homepage from testing-utils crate in [#266](https://github.com/Layr-Labs/eigensdk-rs/pull/266).
 
 ## [0.1.3] - 2024-01-17
 ### Added 🎉

--- a/crates/chainio/clients/fireblocks/src/contract_call.rs
+++ b/crates/chainio/clients/fireblocks/src/contract_call.rs
@@ -143,6 +143,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg(feature = "fireblock-tests")]
+    #[ignore]
     async fn test_contract_call() {
         let api_key = env::var("FIREBLOCKS_API_KEY").expect("FIREBLOCKS_API_KEY not set");
         let private_key_path =

--- a/testing/testing-utils/Cargo.toml
+++ b/testing/testing-utils/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license-file.workspace = true
-homepage.workspace = true
 repository.workspace = true
 
 [lints]


### PR DESCRIPTION
Fixes #

### What Changed?
Removes hompage from testing utils. This used to throw error when deploying on crates io which i used to remove manually 
### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
