### PR TITLE
refactor: move bindings generation to script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,13 @@ __BINDINGS__: ##
 bindings_host:
 	@echo "Generating bindings..."
 	./scripts/generate_bindings.sh
+	cargo fmt --all
 	@echo "Bindings generated"
 
 .PHONY: bindings
 bindings:
 	@echo "Starting Docker container..."
-	@docker run --rm -v "$(PWD):$(PWD)" -w "$(PWD)" \
+	@docker run --rm -v "$(PWD):/sdk" -w "/sdk" \
 		ghcr.io/foundry-rs/foundry:v0.3.0 \
-		-c './scripts/generate_bindings.sh'
+		-c scripts/generate_bindings.sh
+	cargo fmt --all

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,40 @@
 __CONTRACTS__: ##
 
+PHONY: start-anvil-chain-with-contracts-deployed
 start-anvil-chain-with-contracts-deployed: ##
 	./crates/contracts/anvil/start-anvil-chain-with-el-and-avs-deployed.sh
 
+PHONY: start-anvil-chain-with-contracts-deployed
 deploy-contracts-to-anvil-and-save-state: ##
 	./crates/contracts/anvil/deploy-contracts-save-anvil-state.sh
 
 __TESTING__: ##
 
+PHONY: start-anvil
 start-anvil: reset-anvil ##
 	$(MAKE) start-anvil-chain-with-contracts-deployed
 
+PHONY: reset-anvil
 reset-anvil:
 	-docker stop anvil
 	-docker rm anvil
 
+PHONY: coverage
 coverage:
 	cargo llvm-cov --lcov --output-path lcov.info --workspace --features fireblock-tests
 	cargo llvm-cov report --html
 
+PHONY: deps
 deps:
 	@if ! command -v cargo-llvm-cov &> /dev/null; then \
 		cargo install cargo-llvm-cov; \
 	fi
 
+PHONY: fireblocks-tests
 fireblocks-tests:
 	cargo test --package eigen-client-fireblocks --features fireblock-tests
 
+PHONY: lint
 lint:
 	cargo fmt --all -- --check \
 		&& cargo clippy --workspace --all-features --benches --examples --tests -- -D warnings

--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -6,7 +6,7 @@ set +e
 # Print each command executed (useful for debugging)
 # set -o xtrace
 
-function generate_flags() {
+generate_flags() {
     for contract in $@; do
         echo "$acc --select ^$contract\$"
     done

--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set +e
+
+function generate_flags() {
+    acc=""
+    for contract in $@; do
+        acc="$acc --select '^$contract\$'"
+    done
+    echo $acc
+}
+
+# cd to the directory of this script so that this can be run from anywhere
+parent_path=$(
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    pwd -P
+)
+repo_root=$parent_path/..
+cd $repo_root
+
+### SDK bindings ###
+SDK_CONTRACTS="MockAvsServiceManager ContractsRegistry MockERC20"
+SDK_CONTRACTS_LOCATION=crates/contracts
+SDK_BINDINGS_PATH=crates/utils/src/sdk
+# The echo is to remove quotes, and the patsubst to make the regex match the full text only
+SDK_CONTRACTS_ARGS=$(generate_flags $SDK_CONTRACTS)
+
+
+### Middleware bindings ###
+MIDDLEWARE_CONTRACTS="RegistryCoordinator IndexRegistry OperatorStateRetriever StakeRegistry BLSApkRegistry IBLSSignatureChecker ServiceManagerBase IERC20"
+MIDDLEWARE_CONTRACTS_LOCATION=$SDK_CONTRACTS_LOCATION/lib/eigenlayer-middleware
+MIDDLEWARE_BINDINGS_PATH=crates/utils/src/middleware
+# The echo is to remove quotes, and the patsubst to make the regex match the full text only
+MIDDLEWARE_CONTRACTS_ARGS=$(generate_flags $MIDDLEWARE_CONTRACTS)
+
+
+### Core bindings ###
+CORE_CONTRACTS="DelegationManager IRewardsCoordinator RewardsCoordinator  StrategyManager IEigenPod EigenPod IEigenPodManager EigenPodManager IStrategy AVSDirectory AllocationManager PermissionController ERC20 Slasher ISlasher"
+CORE_CONTRACTS_LOCATION=$MIDDLEWARE_CONTRACTS_LOCATION/lib/eigenlayer-contracts
+CORE_BINDINGS_PATH=crates/utils/src/core
+# The echo is to remove quotes, and the patsubst to make the regex match the full text only
+CORE_CONTRACTS_ARGS=$(generate_flags $CORE_CONTRACTS)
+
+# Fetch submodules
+cd $SDK_CONTRACTS_LOCATION && forge install
+cd $repo_root
+
+# Empty the directories before generating the bindings, ignore any errors
+rm $SDK_BINDINGS_PATH/* || true
+rm $MIDDLEWARE_BINDINGS_PATH/* || true
+rm $CORE_BINDINGS_PATH/* || true
+
+# Compile all contracts
+cd $repo_root/$SDK_CONTRACTS_LOCATION && forge build --force --skip test --skip script
+cd $repo_root/$MIDDLEWARE_CONTRACTS_LOCATION && forge build --force --skip test --skip script
+cd $repo_root/$CORE_CONTRACTS_LOCATION && forge build --force --skip test --skip script
+
+# Move back to repo root
+cd $repo_root
+
+# Generate SDK bindings
+forge bind --alloy --skip-build --bindings-path $SDK_BINDINGS_PATH --overwrite \
+    --root $SDK_CONTRACTS_LOCATION --module \
+    $SDK_CONTRACTS_ARGS
+
+# Generate middleware bindings
+forge bind --alloy --skip-build --bindings-path $MIDDLEWARE_BINDINGS_PATH --overwrite \
+    --root $MIDDLEWARE_CONTRACTS_LOCATION --module \
+    $MIDDLEWARE_CONTRACTS_ARGS
+
+# Generate core bindings
+forge bind --alloy --skip-build --bindings-path $CORE_BINDINGS_PATH --overwrite \
+    --root $CORE_CONTRACTS_LOCATION --module \
+    $CORE_CONTRACTS_ARGS

--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -1,13 +1,15 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
+# Exit if any command fails
 set +e
 
+# Print each command executed (useful for debugging)
+# set -o xtrace
+
 function generate_flags() {
-    acc=""
     for contract in $@; do
-        acc="$acc --select '^$contract\$'"
+        echo "$acc --select ^$contract\$"
     done
-    echo $acc
 }
 
 # cd to the directory of this script so that this can be run from anywhere

--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -14,7 +14,7 @@ function generate_flags() {
 
 # cd to the directory of this script so that this can be run from anywhere
 parent_path=$(
-    cd "$(dirname "${BASH_SOURCE[0]}")"
+    cd "$(dirname "$0")"
     pwd -P
 )
 repo_root=$parent_path/..


### PR DESCRIPTION
Fixes #

### What Changed?

This PR moves the bindings generation logic to a script, to avoid having to install `make` in the docker image.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
