### PR TITLE
feat: new method `set_rewards_initiator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,6 +2552,7 @@ dependencies = [
  "eigen-testing-utils",
  "eigen-types",
  "eigen-utils",
+ "futures-util",
  "hex",
  "num-bigint 0.4.6",
  "once_cell",

--- a/crates/chainio/clients/avsregistry/Cargo.toml
+++ b/crates/chainio/clients/avsregistry/Cargo.toml
@@ -34,3 +34,4 @@ eigen-testing-utils.workspace = true
 hex = "0.4.3"
 once_cell.workspace = true
 tokio = { version = "1.37.0", features = ["test-util", "full", "sync"] }
+futures-util.workspace = true

--- a/crates/chainio/clients/avsregistry/src/writer.rs
+++ b/crates/chainio/clients/avsregistry/src/writer.rs
@@ -313,16 +313,22 @@ impl AvsRegistryChainWriter {
         Ok(*tx.tx_hash())
     }
 
-    /// TODO!
+    /// Set a new address as the rewards initiator
+    ///
+    /// # Arguments
+    /// * `rewards_initiator` - The new address to set as the rewards initiator
+    ///
+    /// # Returns
+    /// * `TxHash` - The transaction hash of the set rewards initiator transaction
     pub async fn set_rewards_initiator(
         &self,
         rewards_initiator: Address,
     ) -> Result<TxHash, AvsRegistryError> {
+        info!("setting a new address as the rewards initiator");
         let provider = get_signer(&self.signer.clone(), &self.provider);
 
         let service_manager_base_instance =
             ServiceManagerBase::new(self.service_manager_addr, provider);
-        dbg!(&service_manager_base_instance);
         let contract_call = service_manager_base_instance.setRewardsInitiator(rewards_initiator);
 
         let tx = contract_call
@@ -331,7 +337,6 @@ impl AvsRegistryChainWriter {
             .map_err(AvsRegistryError::AlloyContractError)?;
 
         info!(tx_hash = ?tx,"successfully set rewards initiator" );
-        dbg!(&service_manager_base_instance);
         Ok(*tx.tx_hash())
     }
 }
@@ -416,12 +421,9 @@ mod tests {
             .await
             .unwrap();
 
-        let tx_status = wait_transaction(&http_endpoint, tx_hash)
-            .await
-            .unwrap()
-            .status();
+        let tx_status = wait_transaction(&http_endpoint, tx_hash).await.unwrap();
 
-        assert!(tx_status);
+        assert!(tx_status.status());
     }
 
     // this function is caller from test_avs_writer_methods

--- a/crates/chainio/clients/avsregistry/src/writer.rs
+++ b/crates/chainio/clients/avsregistry/src/writer.rs
@@ -312,6 +312,28 @@ impl AvsRegistryChainWriter {
         info!(tx_hash = ?tx,"successfully deregistered operator with the AVS's registry coordinator" );
         Ok(*tx.tx_hash())
     }
+
+    /// TODO!
+    pub async fn set_rewards_initiator(
+        &self,
+        rewards_initiator: Address,
+    ) -> Result<TxHash, AvsRegistryError> {
+        let provider = get_signer(&self.signer.clone(), &self.provider);
+
+        let service_manager_base_instance =
+            ServiceManagerBase::new(self.service_manager_addr, provider);
+        dbg!(&service_manager_base_instance);
+        let contract_call = service_manager_base_instance.setRewardsInitiator(rewards_initiator);
+
+        let tx = contract_call
+            .send()
+            .await
+            .map_err(AvsRegistryError::AlloyContractError)?;
+
+        info!(tx_hash = ?tx,"successfully set rewards initiator" );
+        dbg!(&service_manager_base_instance);
+        Ok(*tx.tx_hash())
+    }
 }
 
 #[cfg(test)]
@@ -375,7 +397,7 @@ mod tests {
             http_endpoint.clone(),
         )
         .await;
-        test_deregister_operator(&avs_writer, quorum_nums, http_endpoint).await;
+        test_deregister_operator(&avs_writer, quorum_nums, http_endpoint.clone()).await;
     }
 
     // this function is caller from test_avs_writer_methods

--- a/crates/chainio/clients/avsregistry/src/writer.rs
+++ b/crates/chainio/clients/avsregistry/src/writer.rs
@@ -400,6 +400,30 @@ mod tests {
         test_deregister_operator(&avs_writer, quorum_nums, http_endpoint.clone()).await;
     }
 
+    #[tokio::test]
+    async fn test_set_rewards_initiator() {
+        let (_container, http_endpoint, _ws_endpoint) = start_anvil_container().await;
+
+        let private_key =
+            "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string();
+        let avs_writer =
+            build_avs_registry_chain_writer(http_endpoint.clone(), private_key.clone()).await;
+
+        let tx_hash = avs_writer
+            .set_rewards_initiator(
+                Address::from_str("a0Ee7A142d267C1f36714E4a8F75612F20a7972a").unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let tx_status = wait_transaction(&http_endpoint, tx_hash)
+            .await
+            .unwrap()
+            .status();
+
+        assert!(tx_status);
+    }
+
     // this function is caller from test_avs_writer_methods
     async fn test_update_stake_of_operator_subset(
         avs_writer: &AvsRegistryChainWriter,


### PR DESCRIPTION
### What Changed?
Add new method `set_rewards_initiator` to `avsregistry/writer` as this method was missing in the SDK.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
