### PR TITLE
release-plz custom configuration

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -32,27 +32,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-  # Create a PR with the new versions and changelog, preparing the next release.
-  release-plz-pr:
-    name: Release-plz PR
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    concurrency:
-      group: release-plz-${{ github.ref }}
-      cancel-in-progress: false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Run release-plz
-        uses: release-plz/action@v0.5
-        with:
-          command: release-pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -32,4 +32,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-  
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 ### Added
 * Added bindings for `ECDSAStakeRegistry` and `ECDSAServiceManagerBase` in [#269](https://github.com/Layr-Labs/eigensdk-rs/pull/269).
 * Added release-plz in ci in [#275](https://github.com/Layr-Labs/eigensdk-rs/pull/275).
+* Removed changelog generation by release-plz in [#281](https://github.com/Layr-Labs/eigensdk-rs/pull/281).
 
 ### Changed
 * Changes in the way bindings are generated in [#245](https://github.com/Layr-Labs/eigensdk-rs/pull/243).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 ### Added
 * Added bindings for `ECDSAStakeRegistry` and `ECDSAServiceManagerBase` in [#269](https://github.com/Layr-Labs/eigensdk-rs/pull/269).
 * Added release-plz in ci in [#275](https://github.com/Layr-Labs/eigensdk-rs/pull/275).
-* Removed changelog generation by release-plz in [#281](https://github.com/Layr-Labs/eigensdk-rs/pull/281).
 
 ### Changed
 * Changes in the way bindings are generated in [#245](https://github.com/Layr-Labs/eigensdk-rs/pull/243).
@@ -23,6 +22,7 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 
 ### Breaking changes
 ### Removed
+* Removed changelog generation by release-plz in [#281](https://github.com/Layr-Labs/eigensdk-rs/pull/281).
 
 ## [0.1.3] - 2024-01-17
 ### Added 🎉

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,24 @@
+[workspace]
+changelog_update = false # disable changelog updates
+dependencies_update = true # update dependencies with `cargo update`
+git_release_enable = true # enable GitHub/Gitea releases
+pr_branch_prefix = "release-plz-" # PR branch prefix
+pr_name = "Release {{ package }} v{{ version }}" # template for the PR name
+pr_labels = ["release"] # add the `release` label to the release Pull Request
+release_always = false
+
+[[package]]
+name = "info-operator-service"
+release = false # don't process this package
+
+[[package]]
+name = examples-avsregistry-read"
+release = false # don't process this package
+
+[[package]]
+name = "examples-avsregistry-write"
+release = false # don't process this package
+
+[[package]]
+name = "examples-anvil-utils"
+release = false # don't process this package

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,6 +6,7 @@ pr_branch_prefix = "release-plz-" # PR branch prefix
 pr_name = "Release {{ package }} v{{ version }}" # template for the PR name
 pr_labels = ["release"] # add the `release` label to the release Pull Request
 release_always = false
+git_release_draft = true
 
 [[package]]
 name = "info-operator-service"


### PR DESCRIPTION
Fixes #

### What Changed?
- release-plz will not generate changelog  . We will do it as we are doing right now i.e single changelog
- add a release-plz.toml for configuration to automatically do a github release.
-  only release when a PR is merged .
-  Exclude example packages
### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
