### PR TITLE
ci: split tests and coverage

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,6 +47,34 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Install testing tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: docker
+        uses: docker/setup-docker-action@v4
+
+      - name: Run tests and generate code coverage
+        run: cargo nextest run --workspace
+
+  coverage:
+    name: Generate coverage report
+    runs-on: ubuntu-latest
     env:
       HOLESKY_WS_URL: ${{ secrets.HOLESKY_WS_URL }}
       HOLESKY_HTTP_URL: ${{ secrets.HOLESKY_HTTP_URL }}
@@ -61,7 +89,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      
+
       - name: Create private key file
         run: printf "%b" "$FIREBLOCKS_PRIVATE_KEY" > fireblocks_secret.key
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,16 +61,11 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Install nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
-
       - name: docker
         uses: docker/setup-docker-action@v4
 
       - name: Run tests
-        run: cargo nextest run --workspace
+        run: cargo test --workspace
 
   coverage:
     name: Generate Coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Install testing tools
+      - name: Install nextest
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
@@ -69,11 +69,11 @@ jobs:
       - name: docker
         uses: docker/setup-docker-action@v4
 
-      - name: Run tests and generate code coverage
+      - name: Run tests
         run: cargo nextest run --workspace
 
   coverage:
-    name: Generate coverage report
+    name: Generate Coverage
     runs-on: ubuntu-latest
     env:
       HOLESKY_WS_URL: ${{ secrets.HOLESKY_WS_URL }}
@@ -104,7 +104,7 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Install testing tools
+      - name: Install llvm-cov
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,9 +52,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -81,9 +79,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Create private key file
         run: printf "%b" "$FIREBLOCKS_PRIVATE_KEY" > fireblocks_secret.key

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -96,9 +96,6 @@ jobs:
       - name: Set environment variable for private key path
         run: echo "FIREBLOCKS_PRIVATE_KEY_PATH=$(pwd)/fireblocks_secret.key" >> $GITHUB_ENV
 
-      - name: Install nightly Rust
-        run: rustup toolchain install nightly
-
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Fixes #

### What Changed?

Fireblocks tests don't work for external contributors. This PR splits the test run in the CI into two: "Run Tests" and "Generate Coverage". The idea is to have the first one run without fireblocks, while the second one runs with it and is not required for merge.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
