### PR TITLE
remove examples  from workspace.dependencies in Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Each version will have a separate `Breaking Changes` section as well. To describ
 * Fixed the rewardsv2 bindings version in readme to 0.5.4 in [#246](https://github.com/Layr-Labs/eigensdk-rs/pull/246).
 * Fixed typo in release-plz toml file in [#284](https://github.com/Layr-Labs/eigensdk-rs/pull/284).
 * Fixed incorrect package name in Cargo.toml for examples in [#285](https://github.com/Layr-Labs/eigensdk-rs/pull/285).
+* Removed examples packages from workspace.dependencies in Cargo.toml in [#287](https://github.com/Layr-Labs/eigensdk-rs/pull/287).
 
 ### Breaking changes
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,6 @@ futures = "0.3"
 hex = "0.4"
 hex-literal = "0.4"
 hyper = "0.5"
-info-operator-service = { path = "examples/info-operator-service" }
 k256 = "0.13"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.16.1"
@@ -126,7 +125,6 @@ uuid = { version = "1.11", features = ["v4"] }
 parking_lot = "0.12"
 
 
-examples-anvil-utils = { path = "examples/anvil-utils" }
 
 # alloy
 alloy = { version = "0.9", features = [
@@ -138,5 +136,3 @@ alloy = { version = "0.9", features = [
     "json-rpc",
 ] }
 
-examples-avsregistry-read = { path = "examples/avsregistry-read" }
-examples-avsregistry-write = { path = "examples/avsregistry-write" }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,19 +7,3 @@ pr_name = "Release {{ package }} v{{ version }}" # template for the PR name
 pr_labels = ["release"] # add the `release` label to the release Pull Request
 release_always = false
 git_release_draft = true
-
-[[package]]
-name = "info-operator-service"
-release = false # don't process this package
-
-[[package]]
-name = "examples-avsregistry-read"
-release = false # don't process this package
-
-[[package]]
-name = "examples-avsregistry-write"
-release = false # don't process this package
-
-[[package]]
-name = "examples-anvil-utils"
-release = false # don't process this package


### PR DESCRIPTION
Fixes #

### What Changed?
remove examples from workspace.dependencies and thereby remove mention in release-plz.toml
### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
