### PR TITLE
feat: add new method `set_operator_set_param` in `avsregistry/writer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ Those changes in added, changed or breaking changes, should include usage exampl
   ```
 * Added custom configuration for release-plz in [#281](https://github.com/Layr-Labs/eigensdk-rs/pull/281).
 * Added Rewards2.1 support in [#323](https://github.com/Layr-Labs/eigensdk-rs/pull/323).
+* Added new method `set_operator_set_param` in `avsregistry/writer` in [#327](https://github.com/Layr-Labs/eigensdk-rs/pull/327).
+  ```rust
+   let operator_set_params = OperatorSetParam {
+        maxOperatorCount: 10,
+        kickBIPsOfOperatorStake: 50,
+        kickBIPsOfTotalStake: 50,
+    };
+
+    let tx_hash = avs_writer
+        .set_operator_set_param(0, operator_set_params.clone())
+        .await
+        .unwrap();
+  ```
 
 ### Changed
 * Changes in the way bindings are generated in [#243](https://github.com/Layr-Labs/eigensdk-rs/pull/243).

--- a/crates/chainio/clients/avsregistry/src/writer.rs
+++ b/crates/chainio/clients/avsregistry/src/writer.rs
@@ -597,5 +597,63 @@ mod tests {
         // Assert that event socket is the same as passed in the update socket function
         let mut stream = poller.into_stream();
         let (stream_event, _) = stream.next().await.unwrap().unwrap();
+
+        assert_eq!(stream_event.socket, new_socket_addr);
+    }
+
+    #[tokio::test]
+    async fn test_set_operator_set_param() {
+        let (_container, http_endpoint, _ws_endpoint) = start_m2_anvil_container().await;
+        let bls_key =
+            "1371012690269088913462269866874713266643928125698382731338806296762673180359922"
+                .to_string();
+        let private_key = ANVIL_FIRST_PRIVATE_KEY.to_string();
+        let avs_writer =
+            build_avs_registry_chain_writer(http_endpoint.clone(), private_key.clone()).await;
+        let quorum_nums = Bytes::from([0]);
+
+        test_register_operator(&avs_writer, bls_key, quorum_nums, http_endpoint.clone()).await;
+
+        let registry_coordinator_contract = RegistryCoordinator::new(
+            avs_writer.registry_coordinator_addr,
+            get_signer(&avs_writer.signer.clone(), &avs_writer.provider),
+        );
+
+        let operator_set_params = OperatorSetParam {
+            maxOperatorCount: 10,
+            kickBIPsOfOperatorStake: 50,
+            kickBIPsOfTotalStake: 50,
+        };
+
+        let tx_hash = avs_writer
+            .set_operator_set_param(0, operator_set_params.clone())
+            .await
+            .unwrap();
+
+        let tx_status = wait_transaction(&http_endpoint, tx_hash)
+            .await
+            .unwrap()
+            .status();
+
+        assert!(tx_status);
+
+        let op_params = registry_coordinator_contract
+            .getOperatorSetParams(0)
+            .call()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            op_params._0.maxOperatorCount,
+            operator_set_params.maxOperatorCount
+        );
+        assert_eq!(
+            op_params._0.kickBIPsOfOperatorStake,
+            operator_set_params.kickBIPsOfOperatorStake
+        );
+        assert_eq!(
+            op_params._0.kickBIPsOfTotalStake,
+            operator_set_params.kickBIPsOfTotalStake
+        );
     }
 }

--- a/crates/chainio/clients/avsregistry/src/writer.rs
+++ b/crates/chainio/clients/avsregistry/src/writer.rs
@@ -361,7 +361,14 @@ impl AvsRegistryChainWriter {
         Ok(*tx.tx_hash())
     }
 
-    /// TODO!
+    /// Update an existing quorum configuration
+    ///
+    /// # Arguments
+    /// * `quorum_number` - the quorum number to update
+    /// * `operator_set_params` - the new config with [`OperatorSetParam`]
+    ///
+    /// # Returns
+    /// * `TxHash` - The transaction hash of the set operator set param transaction
     pub async fn set_operator_set_param(
         &self,
         quorum_number: u8,

--- a/crates/chainio/clients/avsregistry/src/writer.rs
+++ b/crates/chainio/clients/avsregistry/src/writer.rs
@@ -361,7 +361,7 @@ impl AvsRegistryChainWriter {
         Ok(*tx.tx_hash())
     }
 
-    /// Update an existing quorum configuration
+    /// Update the configuration of an existing quorum.
     ///
     /// # Arguments
     /// * `quorum_number` - the quorum number to update


### PR DESCRIPTION
### What Changed?
Add new method `set_operator_set_param` to `avsregistry/writer`.

Related issue #310 

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
