### PR TITLE
refactor: reduce code duplication in anvil utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,8 +87,9 @@ Those changes in added, changed or breaking changes, should include usage exampl
 ### Removed 🗑
 
 * Removed `eigen-testing-utils` dependency from `eigen-cli` crate in [#353](https://github.com/Layr-Labs/eigensdk-rs/pull/353).
-* Removed `mine_anvil_blocks_operator_set` from `eigen-testing-utils` in [#357](https://github.com/Layr-Labs/eigensdk-rs/pull/357).
-  * Users should use `mine_anvil_blocks` that does the same thing.
+* Modifications to `eigen-testing-utils` in [#357](https://github.com/Layr-Labs/eigensdk-rs/pull/357).
+  * Removed `mine_anvil_blocks_operator_set` from `eigen-testing-utils`. Users should use `mine_anvil_blocks` that does the same thing.
+  * Removed the third parameter of `set_account_balance`. Now the port used is the default used on `start_anvil_container` and `start_m2_anvil_container`.
 
 ### Documentation 📚
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ Those changes in added, changed or breaking changes, should include usage exampl
 ### Removed 🗑
 
 * Removed `eigen-testing-utils` dependency from `eigen-cli` crate in [#353](https://github.com/Layr-Labs/eigensdk-rs/pull/353).
+* Removed `mine_anvil_blocks_operator_set` from `eigen-testing-utils` in [#357](https://github.com/Layr-Labs/eigensdk-rs/pull/357).
+  * Users should use `mine_anvil_blocks` that does the same thing.
 
 ### Documentation 📚
 

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -853,7 +853,7 @@ mod tests {
     use eigen_common::{get_provider, get_signer};
     use eigen_crypto_bls::BlsKeyPair;
     use eigen_testing_utils::{
-        anvil::{mine_anvil_blocks_operator_set, set_account_balance, start_anvil_container},
+        anvil::{mine_anvil_blocks, set_account_balance, start_anvil_container},
         anvil_constants::{
             get_allocation_manager_address, get_erc20_mock_strategy,
             get_registry_coordinator_address, get_service_manager_address, FIRST_ADDRESS,
@@ -1308,7 +1308,7 @@ mod tests {
             .get_block_number()
             .await
             .unwrap();
-        mine_anvil_blocks_operator_set(&_container, (current_block as u32) + 2).await;
+        mine_anvil_blocks(&_container, (current_block as u32) + 2).await;
         let allocation_delay = el_chain_writer
             .el_chain_reader
             .get_allocation_delay(FIRST_ADDRESS)
@@ -1362,7 +1362,7 @@ mod tests {
             .get_allocation_delay(FIRST_ADDRESS)
             .await
             .unwrap();
-        mine_anvil_blocks_operator_set(&container, allocation_delay).await;
+        mine_anvil_blocks(&container, allocation_delay).await;
 
         let allocation_info = el_chain_writer
             .el_chain_reader

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -914,7 +914,7 @@ mod tests {
         let el_chain_writer =
             new_test_writer(http_endpoint.to_string(), private_key.to_string()).await;
 
-        set_account_balance(&container, address_str, "http://localhost:8546").await;
+        set_account_balance(&container, address_str).await;
         let address = Address::from_str(address_str).unwrap();
 
         let operator = Operator {

--- a/crates/chainio/clients/eth/src/instrumented_client.rs
+++ b/crates/chainio/clients/eth/src/instrumented_client.rs
@@ -1013,7 +1013,7 @@ mod tests {
         let private_key_hex =
             "6b35c6d8110c888de06575b45181bf3f9e6c73451fa5cde812c95a6b31e66ddf".to_string();
         let address = "009440d62dc85c73dbf889b7ad1f4da8b231d2ef";
-        set_account_balance(&container, address, "http://localhost:8546").await;
+        set_account_balance(&container, address).await;
 
         // build the transaction
         let to = address!("a0Ee7A142d267C1f36714E4a8F75612F20a79720");

--- a/crates/services/bls_aggregation/src/bls_agg_test.rs
+++ b/crates/services/bls_aggregation/src/bls_agg_test.rs
@@ -19,10 +19,7 @@ pub mod integration_test {
     use eigen_services_avsregistry::chaincaller::AvsRegistryServiceChainCaller;
     use eigen_services_operatorsinfo::operatorsinfo_inmemory::OperatorInfoServiceInMemory;
     use eigen_testing_utils::{
-        anvil::{
-            mine_anvil_blocks, mine_anvil_blocks_operator_set, start_anvil_container,
-            start_m2_anvil_container,
-        },
+        anvil::{mine_anvil_blocks, start_anvil_container, start_m2_anvil_container},
         anvil_constants::{
             get_allocation_manager_address, get_erc20_mock_strategy,
             get_operator_state_retriever_address, get_permission_controller_address,
@@ -331,7 +328,7 @@ pub mod integration_test {
         let bls_agg_service = BlsAggregatorService::new(avs_registry_service, get_test_logger());
         let current_block_num = provider.get_block_number().await.unwrap();
 
-        mine_anvil_blocks_operator_set(&container, 1).await;
+        mine_anvil_blocks(&container, 1).await;
         // // Create the task related parameters
         let task_index: TaskIndex = 0;
         let time_to_expiry = Duration::from_secs(10);
@@ -615,7 +612,7 @@ pub mod integration_test {
             .await
             .unwrap();
 
-        mine_anvil_blocks_operator_set(&container, 1).await;
+        mine_anvil_blocks(&container, 1).await;
         let current_block_num = provider.get_block_number().await.unwrap();
         // Create avs clients to interact with contracts deployed on anvil
         let avs_registry_reader = AvsRegistryChainReader::new(
@@ -799,7 +796,7 @@ pub mod integration_test {
             .await
             .unwrap();
 
-        mine_anvil_blocks_operator_set(&container, 1).await;
+        mine_anvil_blocks(&container, 1).await;
         let current_block_num = provider.get_block_number().await.unwrap();
         // Create avs clients to interact with contracts deployed on anvil
         let avs_registry_reader = AvsRegistryChainReader::new(
@@ -978,7 +975,7 @@ pub mod integration_test {
             .await
             .unwrap();
 
-        mine_anvil_blocks_operator_set(&container, 1).await;
+        mine_anvil_blocks(&container, 1).await;
         let current_block_num = provider.get_block_number().await.unwrap();
         // Create avs clients to interact with contracts deployed on anvil
         let avs_registry_reader = AvsRegistryChainReader::new(
@@ -1168,7 +1165,7 @@ pub mod integration_test {
             .await
             .unwrap();
 
-        mine_anvil_blocks_operator_set(&container, 1).await;
+        mine_anvil_blocks(&container, 1).await;
         let current_block_num = provider.get_block_number().await.unwrap();
 
         // Create aggregation service

--- a/examples/info-operator-service/examples/get_operator_info.rs
+++ b/examples/info-operator-service/examples/get_operator_info.rs
@@ -37,7 +37,7 @@ async fn main() {
     let operator_address = "009440d62dc85c73dbf889b7ad1f4da8b231d2ef";
     let operator_bls_key =
         "12248929636257230549931416853095037629726205319386239410403476017439825112537";
-    set_account_balance(&container, operator_address, "http://localhost:8546").await;
+    set_account_balance(&container, operator_address).await;
 
     let avs_registry_chain_reader = AvsRegistryChainReader::new(
         get_test_logger().clone(),

--- a/testing/testing-utils/src/anvil.rs
+++ b/testing/testing-utils/src/anvil.rs
@@ -95,17 +95,11 @@ pub async fn start_anvil_container() -> (ContainerAsync<GenericImage>, String, S
 }
 
 /// Deposit 1 eth to the account in anvil
-pub async fn set_account_balance(
-    container: &ContainerAsync<GenericImage>,
-    address: &str,
-    port: &str,
-) {
+pub async fn set_account_balance(container: &ContainerAsync<GenericImage>, address: &str) {
     let mut output = container
         .exec(ExecCommand::new([
             "cast",
             "rpc",
-            "--rpc-url",
-            port,
             "anvil_setBalance",
             address,
             "0xDE0B6B3A7640000", // 1 ETH in WEI

--- a/testing/testing-utils/src/anvil.rs
+++ b/testing/testing-utils/src/anvil.rs
@@ -39,28 +39,11 @@ pub async fn mine_anvil_blocks(container: &ContainerAsync<GenericImage>, n: u32)
     assert_eq!(output.exit_code().await.unwrap().unwrap(), 0);
 }
 
-/// Mine anvil block for 8546
-pub async fn mine_anvil_blocks_operator_set(container: &ContainerAsync<GenericImage>, n: u32) {
-    let mut output = container
-        .exec(ExecCommand::new([
-            "cast",
-            "rpc",
-            "--rpc-url",
-            "http://localhost:8546",
-            "anvil_mine",
-            n.to_string().as_str(),
-        ]))
-        .await
-        .expect("Failed to mine anvil blocks");
-
-    // blocking operation until the mining execution finishes
-    output.stdout_to_vec().await.unwrap();
-    assert_eq!(output.exit_code().await.unwrap().unwrap(), 0);
-}
-
 /// Start an anvil container for testing, using the dump state file `ANVIL_STATE_PATH`
-pub async fn start_m2_anvil_container() -> (ContainerAsync<GenericImage>, String, String) {
-    let relative_path = PathBuf::from(M2_ANVIL_STATE_PATH);
+async fn start_anvil_with_state(
+    state_path: &str,
+) -> (ContainerAsync<GenericImage>, String, String) {
+    let relative_path = PathBuf::from(state_path);
     let absolute_path = workspace_dir().join(relative_path);
     let absolute_path_str = absolute_path.to_str().unwrap();
 
@@ -81,6 +64,8 @@ pub async fn start_m2_anvil_container() -> (ContainerAsync<GenericImage>, String
             "0",
             "--gas-price",
             "0",
+            "--port",
+            "8545",
         ])
         .start()
         .await
@@ -90,56 +75,23 @@ pub async fn start_m2_anvil_container() -> (ContainerAsync<GenericImage>, String
         .ports()
         .await
         .unwrap()
-        .map_to_host_port_ipv4(8545)
+        .map_to_host_port_ipv4(8545.tcp())
         .unwrap();
 
-    let http_endpoint = format!("http://localhost:{}", port);
-    let ws_endpoint = format!("ws://localhost:{}", port);
+    let http_endpoint = format!("http://localhost:{port}");
+    let ws_endpoint = format!("ws://localhost:{port}");
 
     (container, http_endpoint, ws_endpoint)
 }
 
-/// Start an anvil container for testing, using the dump state file `ANVIL_STATE_PATH`
+/// Start an anvil container for testing, using the dump state file for M2 contracts
+pub async fn start_m2_anvil_container() -> (ContainerAsync<GenericImage>, String, String) {
+    start_anvil_with_state(M2_ANVIL_STATE_PATH).await
+}
+
+/// Start an anvil container for testing, using the dump state file for operator sets
 pub async fn start_anvil_container() -> (ContainerAsync<GenericImage>, String, String) {
-    let relative_path = PathBuf::from(OPERATOR_SET_ANVIL_STATE_PATH);
-    let absolute_path = workspace_dir().join(relative_path);
-    let absolute_path_str = absolute_path.to_str().unwrap();
-
-    let container = GenericImage::new(ANVIL_IMAGE, ANVIL_TAG)
-        .with_entrypoint("anvil")
-        .with_wait_for(WaitFor::message_on_stdout("Listening on"))
-        .with_exposed_port(8546.tcp())
-        .with_mount(testcontainers::core::Mount::bind_mount(
-            absolute_path_str,
-            "/state.json",
-        ))
-        .with_cmd([
-            "--host",
-            "0.0.0.0",
-            "--load-state",
-            "/state.json",
-            "--base-fee",
-            "0",
-            "--gas-price",
-            "0",
-            "--port",
-            "8546",
-        ])
-        .start()
-        .await
-        .unwrap();
-
-    let port = container
-        .ports()
-        .await
-        .unwrap()
-        .map_to_host_port_ipv4(8546)
-        .unwrap();
-
-    let http_endpoint = format!("http://localhost:{}", port);
-    let ws_endpoint = format!("ws://localhost:{}", port);
-
-    (container, http_endpoint, ws_endpoint)
+    start_anvil_with_state(OPERATOR_SET_ANVIL_STATE_PATH).await
 }
 
 /// Deposit 1 eth to the account in anvil


### PR DESCRIPTION
Fixes #

### What Changed?

This PR extracts common code in `start_m2_anvil_container` and `start_anvil_container`. It also removes the `mine_anvil_blocks_operator_set` function, since it's no longer useful.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
