### PR TITLE
TaskMetadata.task_created_block field changed to u64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ Those changes in added, changed or breaking changes, should include usage exampl
 
 ### Breaking Changes 🛠
 
-* TaskMetadata.task_created_block field changed to u64 [#362](https://github.com/Layr-Labs/eigensdk-rs/pull/362)
+* `TaskMetadata.task_created_block` field changed to `u64` [#362](https://github.com/Layr-Labs/eigensdk-rs/pull/362)
 
 ### Deprecated ⚠️
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Those changes in added, changed or breaking changes, should include usage exampl
 
 ### Breaking Changes 🛠
 
+* TaskMetadata.task_created_block field changed to u64 [#362](https://github.com/Layr-Labs/eigensdk-rs/pull/362)
+
 ### Deprecated ⚠️
 
 ### Removed 🗑

--- a/crates/chainio/clients/avsregistry/src/fake_reader.rs
+++ b/crates/chainio/clients/avsregistry/src/fake_reader.rs
@@ -34,7 +34,7 @@ impl FakeAvsRegistryReader {
 impl AvsRegistryReader for FakeAvsRegistryReader {
     async fn get_operators_stake_in_quorums_at_block(
         &self,
-        _block_number: u32,
+        _block_number: u64,
         _quorum_numbers: Bytes,
     ) -> Result<Vec<Vec<OperatorStateRetriever::Operator>>, AvsRegistryError> {
         Ok(vec![vec![OperatorStateRetriever::Operator {
@@ -46,7 +46,7 @@ impl AvsRegistryReader for FakeAvsRegistryReader {
 
     async fn get_check_signatures_indices(
         &self,
-        _reference_block_number: u32,
+        _reference_block_number: u64,
         _quorum_numbers: Vec<u8>,
         _non_signer_operator_ids: Vec<FixedBytes<32>>,
     ) -> Result<OperatorStateRetriever::CheckSignaturesIndices, AvsRegistryError> {

--- a/crates/services/avsregistry/src/chaincaller.rs
+++ b/crates/services/avsregistry/src/chaincaller.rs
@@ -37,7 +37,7 @@ impl<R: AvsRegistryReader + Sync, S: OperatorInfoService + Sync> AvsRegistryServ
 {
     async fn get_operators_avs_state_at_block(
         &self,
-        block_num: u32,
+        block_num: u64,
         quorum_nums: &[u8],
     ) -> Result<HashMap<FixedBytes<32>, OperatorAvsState>, AvsRegistryError> {
         let mut operators_avs_state: HashMap<FixedBytes<32>, OperatorAvsState> = HashMap::new();
@@ -76,7 +76,7 @@ impl<R: AvsRegistryReader + Sync, S: OperatorInfoService + Sync> AvsRegistryServ
     async fn get_quorums_avs_state_at_block(
         &self,
         quorum_nums: &[u8],
-        block_num: u32,
+        block_num: u64,
     ) -> Result<HashMap<u8, QuorumAvsState>, AvsRegistryError> {
         let operators_avs_state = self
             .get_operators_avs_state_at_block(block_num, quorum_nums)
@@ -120,7 +120,7 @@ impl<R: AvsRegistryReader + Sync, S: OperatorInfoService + Sync> AvsRegistryServ
 
     async fn get_check_signatures_indices(
         &self,
-        reference_block_number: u32,
+        reference_block_number: u64,
         quorum_numbers: Vec<u8>,
         non_signer_operator_ids: Vec<FixedBytes<32>>,
     ) -> Result<CheckSignaturesIndices, AvsRegistryError> {
@@ -189,7 +189,7 @@ mod tests {
     #[derive(Deserialize, Debug)]
     struct InputOperatorAvsState {
         quorum_numbers: Vec<QuorumNum>,
-        block_num: u32,
+        block_num: u64,
         private_key_decimal: String,
         operator_id: String,
         operator_address: String,
@@ -302,7 +302,7 @@ mod tests {
     async fn test_get_quorum_avs_state() {
         let test_operator = build_test_operator(PRIVATE_KEY_DECIMAL, OPERATOR_ID);
         let quorum_num = 1;
-        let block_num = 1u32;
+        let block_num = 1u64;
         let service =
             build_avs_registry_service_chaincaller(test_operator.clone(), OPERATOR_ADDRESS);
         let quorum_state_per_number = service

--- a/crates/services/avsregistry/src/fake_avs_registry_service.rs
+++ b/crates/services/avsregistry/src/fake_avs_registry_service.rs
@@ -57,7 +57,7 @@ impl FakeAvsRegistryService {
 impl AvsRegistryService for FakeAvsRegistryService {
     async fn get_operators_avs_state_at_block(
         &self,
-        block_number: u32,
+        block_number: u64,
         quorum_nums: &[u8],
     ) -> Result<HashMap<FixedBytes<32>, OperatorAvsState>, AvsRegistryError> {
         let mut operators_state = self
@@ -85,7 +85,7 @@ impl AvsRegistryService for FakeAvsRegistryService {
     async fn get_quorums_avs_state_at_block(
         &self,
         quorum_nums: &[u8],
-        block_num: u32,
+        block_num: u64,
     ) -> Result<HashMap<u8, QuorumAvsState>, AvsRegistryError> {
         let operator_avs_state = self
             .operators
@@ -126,7 +126,7 @@ impl AvsRegistryService for FakeAvsRegistryService {
 
     async fn get_check_signatures_indices(
         &self,
-        _reference_block_number: u32,
+        _reference_block_number: u64,
         _quorum_numbers: Vec<u8>,
         _non_signer_operator_ids: Vec<FixedBytes<32>>,
     ) -> Result<CheckSignaturesIndices, AvsRegistryError> {

--- a/crates/services/avsregistry/src/fake_avs_registry_service.rs
+++ b/crates/services/avsregistry/src/fake_avs_registry_service.rs
@@ -62,7 +62,7 @@ impl AvsRegistryService for FakeAvsRegistryService {
     ) -> Result<HashMap<FixedBytes<32>, OperatorAvsState>, AvsRegistryError> {
         let mut operators_state = self
             .operators
-            .get(&(block_number as u64))
+            .get(&block_number)
             .ok_or(AvsRegistryError::GetOperatorState)
             .cloned()?;
 
@@ -89,7 +89,7 @@ impl AvsRegistryService for FakeAvsRegistryService {
     ) -> Result<HashMap<u8, QuorumAvsState>, AvsRegistryError> {
         let operator_avs_state = self
             .operators
-            .get(&(block_num as u64))
+            .get(&block_num)
             .ok_or(AvsRegistryError::GetOperatorState)?;
         let mut quorum_avs_state: HashMap<QuorumNum, QuorumAvsState> = HashMap::new();
         for quorum_num in quorum_nums {

--- a/crates/services/avsregistry/src/lib.rs
+++ b/crates/services/avsregistry/src/lib.rs
@@ -29,7 +29,7 @@ pub trait AvsRegistryService {
     /// A hashmap containing the operator ID and the operator AVS state
     async fn get_operators_avs_state_at_block(
         &self,
-        block_num: u32,
+        block_num: u64,
         quorum_nums: &[u8],
     ) -> Result<HashMap<FixedBytes<32>, OperatorAvsState>, AvsRegistryError>;
 
@@ -46,7 +46,7 @@ pub trait AvsRegistryService {
     async fn get_quorums_avs_state_at_block(
         &self,
         quorum_nums: &[u8],
-        block_num: u32,
+        block_num: u64,
     ) -> Result<HashMap<u8, QuorumAvsState>, AvsRegistryError>;
 
     /// Get the signatures indices of quorum members for a specific block and checks
@@ -64,7 +64,7 @@ pub trait AvsRegistryService {
     /// and the ones that didn't
     async fn get_check_signatures_indices(
         &self,
-        reference_block_number: u32,
+        reference_block_number: u64,
         quorum_numbers: Vec<u8>,
         non_signer_operator_ids: Vec<FixedBytes<32>>,
     ) -> Result<CheckSignaturesIndices, AvsRegistryError>;

--- a/crates/services/bls_aggregation/src/bls_agg.rs
+++ b/crates/services/bls_aggregation/src/bls_agg.rs
@@ -37,7 +37,7 @@ pub struct TaskMetadata {
     /// Index of the task
     task_index: TaskIndex,
     /// Block the task was created
-    task_created_block: u32, // TODO: Should this be a u64?
+    task_created_block: u64,
     /// Quorum numbers which should respond to the task
     quorum_numbers: Vec<u8>,
     /// Thresholds for each quorum
@@ -69,10 +69,6 @@ impl TaskMetadata {
         quorum_threshold_percentages: QuorumThresholdPercentages,
         time_to_expiry: Duration,
     ) -> Self {
-        let task_created_block: u32 = task_created_block
-            .try_into()
-            .expect("block number should fit into a u32");
-
         Self {
             task_index,
             task_created_block,
@@ -412,7 +408,7 @@ impl<A: AvsRegistryService + Send + Sync + Clone + 'static> BlsAggregatorService
     async fn loop_task_aggregator(
         avs_registry_service: A,
         task_index: TaskIndex,
-        task_created_block: u32,
+        task_created_block: u64,
         time_to_expiry: Duration,
         aggregated_response_sender: UnboundedSender<
             Result<BlsAggregationServiceResponse, BlsAggregationServiceError>,
@@ -655,7 +651,7 @@ impl<A: AvsRegistryService + Send + Sync + Clone + 'static> BlsAggregatorService
     #[allow(clippy::too_many_arguments)]
     async fn build_aggregated_response(
         task_index: TaskIndex,
-        task_created_block: u32,
+        task_created_block: u64,
         signed_task_digest: SignedTaskResponseDigest,
         operator_state_avs: &HashMap<FixedBytes<32>, OperatorAvsState>,
         digest_aggregated_operators: AggregatedOperators,

--- a/crates/types/src/operator.rs
+++ b/crates/types/src/operator.rs
@@ -98,7 +98,7 @@ pub struct QuorumAvsState {
     pub quorum_num: u8,
     pub total_stake: U256,
     pub agg_pub_key_g1: BlsG1Point,
-    pub block_num: u32,
+    pub block_num: u64,
 }
 
 pub type QuorumThresholdPercentage = u8;


### PR DESCRIPTION
Fixes #320

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
