### PR TITLE
add set_signer method in Writer methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,13 @@ Those changes in added, changed or breaking changes, should include usage exampl
       .unwrap();
   ```
 
+* Added new method `set_signer` in `ELChainWriter` and `AvsRegistryChainWriter` in [#364](https://github.com/Layr-Labs/eigensdk-rs/pull/364).
+
+  ```rust
+  avs_registry_chain_writer.set_signer(PRIVATE_KEY_STRING);
+  el_chain_writer.set_signer(PRIVATE_KEY_STRING);
+  ```
+
 ### Breaking Changes 🛠
 
 * `TaskMetadata.task_created_block` field changed to `u64` [#362](https://github.com/Layr-Labs/eigensdk-rs/pull/362)

--- a/crates/chainio/clients/avsregistry/src/writer.rs
+++ b/crates/chainio/clients/avsregistry/src/writer.rs
@@ -112,6 +112,16 @@ impl AvsRegistryChainWriter {
         })
     }
 
+    /// Sets signer for AvsRegistryChainWriter
+    ///
+    /// # Arguments
+    ///
+    /// * `signer` - signer string
+    ///
+    pub async fn set_signer(&mut self, signer: String) {
+        self.signer = signer;
+    }
+
     /// Register operator in quorum with avs registry coordinator
     ///
     /// # Arguments

--- a/crates/chainio/clients/avsregistry/src/writer.rs
+++ b/crates/chainio/clients/avsregistry/src/writer.rs
@@ -118,7 +118,7 @@ impl AvsRegistryChainWriter {
     ///
     /// * `signer` - signer string
     ///
-    pub async fn set_signer(&mut self, signer: String) {
+    pub fn set_signer(&mut self, signer: String) {
         self.signer = signer;
     }
 

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -867,7 +867,7 @@ mod tests {
         anvil_constants::{
             get_allocation_manager_address, get_erc20_mock_strategy,
             get_registry_coordinator_address, get_service_manager_address, FIRST_ADDRESS,
-            FIRST_PRIVATE_KEY, SECOND_PRIVATE_KEY,
+            FIRST_PRIVATE_KEY,
         },
         transaction::wait_transaction,
     };

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -72,6 +72,16 @@ impl ELChainWriter {
         }
     }
 
+    /// Sets signer for ELChainWriter
+    ///
+    /// # Arguments
+    ///
+    /// * `signer`: signer string
+    ///
+    pub async fn set_signer(&mut self, signer: String) {
+        self.signer = signer;
+    }
+
     /// Register an operator to EigenLayer, and wait for the transaction to be mined.
     ///
     /// # Arguments
@@ -857,7 +867,7 @@ mod tests {
         anvil_constants::{
             get_allocation_manager_address, get_erc20_mock_strategy,
             get_registry_coordinator_address, get_service_manager_address, FIRST_ADDRESS,
-            FIRST_PRIVATE_KEY,
+            FIRST_PRIVATE_KEY, SECOND_PRIVATE_KEY,
         },
         transaction::wait_transaction,
     };

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -78,7 +78,7 @@ impl ELChainWriter {
     ///
     /// * `signer`: signer string
     ///
-    pub async fn set_signer(&mut self, signer: String) {
+    pub fn set_signer(&mut self, signer: String) {
         self.signer = signer;
     }
 


### PR DESCRIPTION
Fixes #334

### What Changed?
Added `set-signer ` method .
### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
