### PR TITLE
feat: Add register_as_operator_preslashing method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,23 @@ Those changes in added, changed or breaking changes, should include usage exampl
   el_chain_writer.set_signer(PRIVATE_KEY_STRING);
   ```
 
+* Added additional method `register_as_operator_m2` in `ELChainWriter` in [#366](https://github.com/Layr-Labs/eigensdk-rs/pull/366).This method is to be used for pre operator-sets.
+
+  ```rust
+   let operator = Operator {
+            address: ADDRESS, 
+            delegation_approver_address: ADDRESS,
+            metadata_url: "metadata_uri".to_string(),
+            allocation_delay: None,
+            _deprecated_earnings_receiver_address: None,
+            staker_opt_out_window_blocks: Some(0u32),
+        };
+    el_chain_writer
+        .register_as_operator_m2(operator)
+        .await
+        .unwrap();
+  ```
+
 ### Breaking Changes 🛠
 
 * `TaskMetadata.task_created_block` field changed to `u64` [#362](https://github.com/Layr-Labs/eigensdk-rs/pull/362)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ Those changes in added, changed or breaking changes, should include usage exampl
   el_chain_writer.set_signer(PRIVATE_KEY_STRING);
   ```
 
-* Added additional method `register_as_operator_m2` in `ELChainWriter` in [#366](https://github.com/Layr-Labs/eigensdk-rs/pull/366).This method is to be used for pre operator-sets.
+* Added additional method `register_as_operator_preslashing` in `ELChainWriter` in [#366](https://github.com/Layr-Labs/eigensdk-rs/pull/366).This method is to be used for pre-slashing.
 
   ```rust
    let operator = Operator {
@@ -124,7 +124,7 @@ Those changes in added, changed or breaking changes, should include usage exampl
             staker_opt_out_window_blocks: Some(0u32),
         };
     el_chain_writer
-        .register_as_operator_m2(operator)
+        .register_as_operator_preslashing(operator)
         .await
         .unwrap();
   ```

--- a/crates/chainio/clients/elcontracts/src/error.rs
+++ b/crates/chainio/clients/elcontracts/src/error.rs
@@ -80,4 +80,7 @@ pub enum ElContractsError {
 
     #[error("Permission Controller is not set")]
     MissingParameter,
+
+    #[error("StakerOptOutWindowBlocks is not set")]
+    StakerOptOutWindowBlocksNotSet,
 }

--- a/crates/chainio/clients/elcontracts/src/lib.rs
+++ b/crates/chainio/clients/elcontracts/src/lib.rs
@@ -87,6 +87,24 @@ pub(crate) mod test_utils {
         )
     }
 
+    pub async fn new_test_writer_m2(http_endpoint: String, private_key: String) -> ELChainWriter {
+        let el_chain_reader = build_el_chain_reader(http_endpoint.clone()).await;
+        let strategy_manager = get_strategy_manager_address(http_endpoint.clone()).await;
+        let rewards_coordinator = get_rewards_coordinator_address(http_endpoint.clone()).await;
+        let registry_coordinator = get_registry_coordinator_address(http_endpoint.clone()).await;
+
+        ELChainWriter::new(
+            strategy_manager,
+            rewards_coordinator,
+            None,
+            None,
+            registry_coordinator,
+            el_chain_reader,
+            http_endpoint.clone(),
+            private_key,
+        )
+    }
+
     // Using test data taken from
     // https://github.com/Layr-Labs/eigenlayer-contracts/blob/a888a1cd1479438dda4b138245a69177b125a973/src/test/test-data/rewardsCoordinator/processClaimProofs_MaxEarnerAndLeafIndices.json
     pub async fn new_test_claim(http_endpoint: &str) -> (FixedBytes<32>, RewardsMerkleClaim) {

--- a/crates/chainio/clients/elcontracts/src/lib.rs
+++ b/crates/chainio/clients/elcontracts/src/lib.rs
@@ -87,7 +87,10 @@ pub(crate) mod test_utils {
         )
     }
 
-    pub async fn new_test_writer_m2(http_endpoint: String, private_key: String) -> ELChainWriter {
+    pub async fn new_test_writer_preslashing(
+        http_endpoint: String,
+        private_key: String,
+    ) -> ELChainWriter {
         let el_chain_reader = build_el_chain_reader(http_endpoint.clone()).await;
         let strategy_manager = get_strategy_manager_address(http_endpoint.clone()).await;
         let rewards_coordinator = get_rewards_coordinator_address(http_endpoint.clone()).await;

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -904,8 +904,8 @@ mod test_utils {}
 #[cfg(test)]
 mod tests {
     use crate::test_utils::{
-        build_el_chain_reader, new_claim, new_test_writer, new_test_writer_m2, OPERATOR_ADDRESS,
-        OPERATOR_PRIVATE_KEY,
+        build_el_chain_reader, new_claim, new_test_writer, new_test_writer_preslashing,
+        OPERATOR_ADDRESS, OPERATOR_PRIVATE_KEY,
     };
     use alloy::{
         primitives::{address, aliases::U96, Address, U256},
@@ -974,7 +974,8 @@ mod tests {
         let (_container, http_endpoint, _ws_endpoint) = start_m2_anvil_container().await;
         let el_chain_reader = build_el_chain_reader(http_endpoint.clone()).await;
         let el_chain_writer =
-            new_test_writer_m2(http_endpoint.to_string(), FIRST_PRIVATE_KEY.to_string()).await;
+            new_test_writer_preslashing(http_endpoint.to_string(), FIRST_PRIVATE_KEY.to_string())
+                .await;
 
         let operator = Operator {
             address: FIRST_ADDRESS, // can only register the address corresponding to the signer used in the writer

--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -84,7 +84,7 @@ impl ELChainWriter {
         self.signer = signer;
     }
 
-    pub async fn register_as_operator_m2(
+    pub async fn register_as_operator_preslashing(
         &self,
         operator: Operator,
     ) -> Result<TxHash, ElContractsError> {
@@ -970,7 +970,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_register_operator_m2() {
+    async fn test_register_operator_preslashing() {
         let (_container, http_endpoint, _ws_endpoint) = start_m2_anvil_container().await;
         let el_chain_reader = build_el_chain_reader(http_endpoint.clone()).await;
         let el_chain_writer =
@@ -985,7 +985,7 @@ mod tests {
             staker_opt_out_window_blocks: Some(0u32),
         };
         el_chain_writer
-            .register_as_operator_m2(operator)
+            .register_as_operator_preslashing(operator)
             .await
             .unwrap();
 

--- a/crates/services/operatorsinfo/src/operatorsinfo_inmemory.rs
+++ b/crates/services/operatorsinfo/src/operatorsinfo_inmemory.rs
@@ -765,7 +765,9 @@ mod tests {
             address: signer.address(),
             delegation_approver_address: signer.address(),
             metadata_url: "eigensdk-rs".to_string(),
-            allocation_delay: 0,
+            allocation_delay: Some(0),
+            staker_opt_out_window_blocks: None,
+            _deprecated_earnings_receiver_address: None,
         };
 
         el_chain_writer

--- a/crates/types/src/operator.rs
+++ b/crates/types/src/operator.rs
@@ -73,7 +73,11 @@ pub struct Operator {
 
     /// `allocation_delay` is the delay in seconds where an operator is allowed to change allocation
     /// This can only be set once by the operator. Once set this can't be changed
-    pub allocation_delay: u32,
+    pub allocation_delay: Option<u32>,
+
+    pub _deprecated_earnings_receiver_address: Option<Address>,
+
+    pub staker_opt_out_window_blocks: Option<u32>,
 }
 
 impl Operator {
@@ -81,7 +85,9 @@ impl Operator {
         address: &str,
         delegation_approver_address: &str,
         metadata_url: String,
-        allocation_delay: u32,
+        allocation_delay: Option<u32>,
+        _deprecated_earnings_receiver_address: Option<Address>,
+        staker_opt_out_window_blocks: Option<u32>,
     ) -> Result<Self, OperatorTypesError> {
         let address = Address::try_from(address.as_bytes())
             .map_err(|_| OperatorTypesError::InvalidAddress)?;
@@ -93,6 +99,8 @@ impl Operator {
             delegation_approver_address,
             metadata_url,
             allocation_delay,
+            _deprecated_earnings_receiver_address,
+            staker_opt_out_window_blocks,
         })
     }
 

--- a/examples/avsregistry-write/examples/register_operator_in_quorum_with_avs_registry_coordinator.rs
+++ b/examples/avsregistry-write/examples/register_operator_in_quorum_with_avs_registry_coordinator.rs
@@ -94,7 +94,9 @@ async fn main() -> Result<()> {
         address: wallet.address(),
         delegation_approver_address: wallet.address(),
         metadata_url: "eigensdk-rs".to_string(),
-        allocation_delay: 1,
+        allocation_delay: Some(1u32),
+        _deprecated_earnings_receiver_address: None,
+        staker_opt_out_window_blocks: None,
     };
     // Register the address as operator in delegation manager
     let _s = el_writer.register_as_operator(operator_details).await;

--- a/examples/info-operator-service/examples/get_operator_info.rs
+++ b/examples/info-operator-service/examples/get_operator_info.rs
@@ -119,7 +119,9 @@ pub async fn register_operator(pvt_key: &str, bls_key: &str, http_endpoint: &str
         address: signer.address(),
         delegation_approver_address: signer.address(),
         metadata_url: "eigensdk-rs".to_string(),
-        allocation_delay: 1,
+        allocation_delay: Some(1u32),
+        _deprecated_earnings_receiver_address: None,
+        staker_opt_out_window_blocks: None,
     };
 
     let _ = el_chain_writer


### PR DESCRIPTION
Fixes #

### What Changed?
Adds `register_as_operator_preslashing` along with test.
### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
