### PR TITLE
test: add missing test for query_existing_registered_operator_pub_keys

### DIFF
--- a/crates/chainio/clients/avsregistry/src/reader.rs
+++ b/crates/chainio/clients/avsregistry/src/reader.rs
@@ -1684,4 +1684,49 @@ mod tests {
             .unwrap();
         assert_eq!(total_stake_indices_at_block_number.first(), Some(&1u32));
     }
+
+    #[tokio::test]
+    async fn test_query_existing_registered_operator_pub_keys() {
+        let (_container, http_endpoint, ws_endpoint) = start_m2_anvil_container().await;
+
+        let private_key = FIFTH_PRIVATE_KEY.to_string();
+        let avs_writer = build_avs_registry_chain_writer(http_endpoint.clone(), private_key).await;
+        let avs_reader = build_avs_registry_chain_reader(http_endpoint.clone()).await;
+
+        let bls_key_pair = BlsKeyPair::new(
+            "1371012690269088913462269866874713266643928125698382731338806296762673180359922"
+                .to_string(),
+        )
+        .unwrap();
+        let digest_hash: FixedBytes<32> = FixedBytes::from([0x02; 32]);
+        let quorum_nums = Bytes::from([0]);
+        let signature_expiry = U256::MAX;
+
+        let tx_hash = avs_writer
+            .register_operator_in_quorum_with_avs_registry_coordinator(
+                bls_key_pair.clone(),
+                digest_hash,
+                signature_expiry,
+                quorum_nums.clone(),
+                "".into(),
+            )
+            .await
+            .unwrap();
+        let tx_status = wait_transaction(&http_endpoint, tx_hash)
+            .await
+            .unwrap()
+            .status();
+        assert!(tx_status);
+
+        let operators = avs_reader
+            .query_existing_registered_operator_pub_keys(0, 1000, ws_endpoint)
+            .await
+            .unwrap();
+
+        assert_eq!(*operators.0.first().unwrap(), FIFTH_ADDRESS);
+        assert_eq!(
+            operators.1.first().unwrap().g1_pub_key,
+            BlsG1Point::new(bls_key_pair.public_key().g1()),
+        );
+    }
 }

--- a/crates/chainio/clients/avsregistry/src/reader.rs
+++ b/crates/chainio/clients/avsregistry/src/reader.rs
@@ -1693,11 +1693,7 @@ mod tests {
         let avs_writer = build_avs_registry_chain_writer(http_endpoint.clone(), private_key).await;
         let avs_reader = build_avs_registry_chain_reader(http_endpoint.clone()).await;
 
-        let bls_key_pair = BlsKeyPair::new(
-            "1371012690269088913462269866874713266643928125698382731338806296762673180359922"
-                .to_string(),
-        )
-        .unwrap();
+        let bls_key_pair = BlsKeyPair::new(OPERATOR_BLS_KEY.to_string()).unwrap();
         let digest_hash: FixedBytes<32> = FixedBytes::from([0x02; 32]);
         let quorum_nums = Bytes::from([0]);
         let signature_expiry = U256::MAX;


### PR DESCRIPTION
### What Changed?
This PR adds a test for method `query_existing_registered_operator_pub_keys`

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
