### PR TITLE
fix: type annotations error on nightly

### DIFF
--- a/crates/chainio/clients/avsregistry/src/reader.rs
+++ b/crates/chainio/clients/avsregistry/src/reader.rs
@@ -301,7 +301,7 @@ impl AvsRegistryChainReader {
             .await
             .map_err(|_| AvsRegistryError::GetBlockNumber)?;
 
-        if current_block_number > u32::MAX.into() {
+        if current_block_number > <u32 as Into<u64>>::into(u32::MAX) {
             return Err(AvsRegistryError::BlockNumberOverflow);
         }
 
@@ -384,7 +384,7 @@ impl AvsRegistryChainReader {
             AvsRegistryError::AlloyContractError(alloy::contract::Error::TransportError(e))
         })?;
 
-        if current_block_number > u32::MAX.into() {
+        if current_block_number > <u32 as Into<u64>>::into(u32::MAX) {
             return Err(AvsRegistryError::BlockNumberOverflow);
         }
 


### PR DESCRIPTION
Fixes #

### What Changed?
Adds type annotations to some type conversions in the AVS Registry Reader that were causing errors on Nightly Rust

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
