### PR TITLE
refactor: remove `unwrap` and use `Arc::mutex` in `NodeAPI`

### DIFF
--- a/crates/nodeapi/src/lib.rs
+++ b/crates/nodeapi/src/lib.rs
@@ -236,6 +236,8 @@ mod tests {
             ServiceStatus::Initializing,
         );
 
+        let node_api = Arc::new(Mutex::new(node_api));
+
         let app = App::new()
             .state(node_api.clone())
             .route("/eigen/node", web::get().to(node_info));
@@ -258,7 +260,7 @@ mod tests {
     async fn test_list_services_handler() {
         let tests = vec![
             (
-                NodeApi::new("test_avs", "v0.0.1"),
+                Arc::new(Mutex::new(NodeApi::new("test_avs", "v0.0.1"))),
                 http::StatusCode::OK,
                 "{\"services\":[]}",
             ),
@@ -271,7 +273,7 @@ mod tests {
                         "testServiceDescription",
                         ServiceStatus::Up,
                     );
-                    node_api
+                    Arc::new(Mutex::new(node_api))
                 },
                 http::StatusCode::OK,
                 "{\"services\":[{\"id\":\"testServiceId\",\"name\":\"testServiceName\",\"description\":\"testServiceDescription\",\"status\":\"Up\"}]}",
@@ -291,7 +293,7 @@ mod tests {
                         "testServiceDescription2",
                         ServiceStatus::Down,
                     );
-                    node_api
+                    Arc::new(Mutex::new(node_api))
                 },
                 http::StatusCode::OK,
                 "{\"services\":[{\"id\":\"testServiceId\",\"name\":\"testServiceName\",\"description\":\"testServiceDescription\",\"status\":\"Up\"},{\"id\":\"testServiceId2\",\"name\":\"testServiceName2\",\"description\":\"testServiceDescription2\",\"status\":\"Down\"}]}",
@@ -335,6 +337,8 @@ mod tests {
             "testServiceDescription",
             ServiceStatus::Up,
         );
+
+        let node_api = Arc::new(Mutex::new(node_api));
 
         // Initialize the app with the NodeApi
         let app = test::init_service(App::new().state(node_api.clone()).route(

--- a/crates/nodeapi/src/lib.rs
+++ b/crates/nodeapi/src/lib.rs
@@ -147,7 +147,13 @@ impl NodeApi {
 
 #[allow(unused)]
 pub async fn node_info(api: web::types::State<Arc<Mutex<NodeApi>>>) -> impl Responder {
-    let mut data = api.lock().unwrap(); // TODO! Handle the error
+    let data = match api.lock() {
+        Ok(guard) => guard,
+        Err(err) => {
+            return HttpResponse::InternalServerError()
+                .body(format!("Internal Server Error: {}", err));
+        }
+    };
     let response = serde_json::json!({
         "node_name": data.node_name,
         "node_version": data.node_version,
@@ -158,7 +164,13 @@ pub async fn node_info(api: web::types::State<Arc<Mutex<NodeApi>>>) -> impl Resp
 
 #[allow(unused)]
 pub async fn health_check(api: web::types::State<Arc<Mutex<NodeApi>>>) -> impl Responder {
-    let mut data = api.lock().unwrap(); // TODO! Handle the error
+    let data = match api.lock() {
+        Ok(guard) => guard,
+        Err(err) => {
+            return HttpResponse::InternalServerError()
+                .body(format!("Internal Server Error: {}", err));
+        }
+    };
     let health = &data.health;
 
     match health {
@@ -170,7 +182,13 @@ pub async fn health_check(api: web::types::State<Arc<Mutex<NodeApi>>>) -> impl R
 
 #[allow(unused)]
 pub async fn list_services(api: web::types::State<Arc<Mutex<NodeApi>>>) -> impl Responder {
-    let mut data = api.lock().unwrap(); // TODO! Handle the error
+    let data = match api.lock() {
+        Ok(guard) => guard,
+        Err(err) => {
+            return HttpResponse::InternalServerError()
+                .body(format!("Internal Server Error: {}", err));
+        }
+    };
     let services = &data.services;
     HttpResponse::Ok().json(&serde_json::json!({ "services": *services }))
 }
@@ -181,7 +199,13 @@ pub async fn service_health(
     path: web::types::Path<String>,
 ) -> impl Responder {
     let service_id = path.into_inner();
-    let mut data = api.lock().unwrap(); // TODO! Handle the error
+    let data = match api.lock() {
+        Ok(guard) => guard,
+        Err(err) => {
+            return HttpResponse::InternalServerError()
+                .body(format!("Internal Server Error: {}", err));
+        }
+    };
     let services = &data.services;
 
     if let Some(service) = services.iter().find(|s| s.id == service_id) {


### PR DESCRIPTION
### What Changed?
This PR removes the `unwrap()` in the handlers. We now check if the lock can be acquired and if not, we return an `HttpResponse::InternalServerError()`. Also updated the tests to use `Arc::new(Mutex::new(node_api))`.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
