### PR TITLE
chore: remove unused dependency in `eigen-cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2594,7 +2594,6 @@ dependencies = [
  "eigen-common",
  "eigen-crypto-bls",
  "eigen-testing-utils",
- "eigen-types",
  "eigen-utils",
  "eth-keystore",
  "hex",

--- a/crates/eigen-cli/Cargo.toml
+++ b/crates/eigen-cli/Cargo.toml
@@ -16,7 +16,6 @@ clap.workspace = true
 colored = "2.1.0"
 eigen-common.workspace = true
 eigen-crypto-bls.workspace = true
-eigen-types.workspace = true
 eigen-utils.workspace = true
 eth-keystore.workspace = true
 hex.workspace = true


### PR DESCRIPTION
Fixes #

### What Changed?

This PR removes an unused dependency found by running [`cargo-udeps`](https://github.com/est31/cargo-udeps)

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
