### PR TITLE
feat(v2): build `AvsRegistryChainReader` and `ClientAggregator` inside `start()`

### DIFF
--- a/crates/operator/src/error.rs
+++ b/crates/operator/src/error.rs
@@ -1,3 +1,4 @@
+use eigen_client_avsregistry::error::AvsRegistryError;
 // use eigen_config::error::ConfigError;
 use eigen_crypto_bls::error::BlsError;
 use rust_bls_bn254::errors::KeystoreError;
@@ -7,6 +8,9 @@ use thiserror::Error;
 /// Error returned by AvsRegistry
 #[derive(Debug, Error)]
 pub enum OperatorError {
+    /// AvsRegistry Error
+    #[error("AvsRegistry Error")]
+    AvsRegistry(#[from] AvsRegistryError),
     /// Operator Registration Error
     #[error("Failed to register operator")]
     RegistrationError,

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -42,12 +42,15 @@ impl<TP: OperatorTaskProcessor> Operator<TP> {
     ///
     /// # Arguments
     ///
-    /// * `avs_registry_reader` - The AVS registry reader.
     /// * `key_pair` - The key pair of the operator.
     /// * `operator_address` - The address of the operator.
     /// * `operator_name` - The name of the operator.
-    /// * `client_aggregator` - The client aggregator.
+    /// * `logger` - The logger.
     /// * `ws_rpc_url` - The URL of the WebSocket RPC.
+    /// * `http_rpc_url` - The URL of the HTTP RPC.
+    /// * `registry_coordinator_address` - The address of the registry coordinator.
+    /// * `operator_state_retriever_address` - The address of the operator state retriever.
+    /// * `aggregator_ip_port` - The IP and port of the aggregator.
     /// * `task_processor` - The Operator task processor.
     ///
     /// # Returns

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -61,7 +61,7 @@ impl<TP: OperatorTaskProcessor> Operator<TP> {
         logger: SharedLogger,
         ws_rpc_url: &str,
         http_rpc_url: &str,
-        registry_coordiator_address: Address,
+        registry_coordinator_address: Address,
         operator_state_retriever_address: Address,
         aggregator_ip_port: String,
         task_processor: TP,

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -68,13 +68,13 @@ impl<TP: OperatorTaskProcessor> Operator<TP> {
     ) -> Result<Self, OperatorError> {
         let avs_registry_reader = AvsRegistryChainReader::new(
             logger,
-            registry_coordiator_address,
+            registry_coordinator_address,
             operator_state_retriever_address,
             http_rpc_url.to_string(),
         )
         .await?;
 
-        let client_aggregator = ClientAggregator::new(aggregator_ip_port_address).await?;
+        let client_aggregator = ClientAggregator::new(aggregator_ip_port).await?;
 
         let is_registered = avs_registry_reader
             .is_operator_registered(operator_address)

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -10,6 +10,7 @@ use client::ClientAggregator;
 use eigen_aggregator::{SignedTaskResponse, TaskResponse};
 use eigen_client_avsregistry::reader::AvsRegistryChainReader;
 use eigen_crypto_bls::BlsKeyPair;
+use eigen_logging::logger::SharedLogger;
 use eigen_types::operator::OperatorId;
 use error::OperatorError;
 use futures_util::StreamExt;
@@ -52,15 +53,29 @@ impl<TP: OperatorTaskProcessor> Operator<TP> {
     /// # Returns
     ///
     /// * `Result<Self, OperatorError>` - The operator.
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
-        avs_registry_reader: &AvsRegistryChainReader,
         key_pair: &BlsKeyPair,
         operator_address: Address,
         operator_name: &str,
-        client_aggregator: &ClientAggregator,
+        logger: SharedLogger,
         ws_rpc_url: &str,
+        http_rpc_url: &str,
+        registry_coordiator_address: Address,
+        operator_state_retriever_address: Address,
+        aggregator_ip_port_address: String,
         task_processor: TP,
     ) -> Result<Self, OperatorError> {
+        let avs_registry_reader = AvsRegistryChainReader::new(
+            logger,
+            registry_coordiator_address,
+            operator_state_retriever_address,
+            http_rpc_url.to_string(),
+        )
+        .await?;
+
+        let client_aggregator = ClientAggregator::new(aggregator_ip_port_address).await?;
+
         let is_registered = avs_registry_reader
             .is_operator_registered(operator_address)
             .await

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -63,7 +63,7 @@ impl<TP: OperatorTaskProcessor> Operator<TP> {
         http_rpc_url: &str,
         registry_coordiator_address: Address,
         operator_state_retriever_address: Address,
-        aggregator_ip_port_address: String,
+        aggregator_ip_port: String,
         task_processor: TP,
     ) -> Result<Self, OperatorError> {
         let avs_registry_reader = AvsRegistryChainReader::new(


### PR DESCRIPTION
### What Changed?

Based on the [example](https://github.com/Layr-Labs/eigensdk-rs/pull/436), asked to move the creation of the `AvsRegistryChainReader` and the `ClientAggregator` inside the `start`.


### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
