### PR TITLE
docs: inline `eigensdk` documentation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,3 @@
-[alias]
-docs = "doc --workspace --all-features --no-deps"
-
 [target.x86_64-pc-windows-msvc]
 rustflags = [
     # Increases the stack size to 10MB, which is

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ lint:
 
 .PHONY: docs
 docs:
-	cargo docs --workspace --all-features --no-deps --open
+	cargo doc --workspace --all-features --no-deps --open
 
 .PHONY: copy-env
 copy-env:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ lint:
 
 .PHONY: docs
 docs:
-	cargo doc --features docs --workspace --no-deps --open
+	cargo docs --workspace --all-features --no-deps --open
 
 .PHONY: copy-env
 copy-env:

--- a/crates/eigensdk/Cargo.toml
+++ b/crates/eigensdk/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 description = "SDK for eigenlayer"
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 eigen-client-avsregistry = { workspace = true, optional = true }
 eigen-client-elcontracts = { workspace = true, optional = true }

--- a/crates/eigensdk/src/lib.rs
+++ b/crates/eigensdk/src/lib.rs
@@ -8,82 +8,82 @@
 #[cfg(feature = "types")]
 pub use eigen_types as types;
 
-#[cfg(feature = "utils")]
 #[doc(inline)]
+#[cfg(feature = "utils")]
 pub use eigen_utils as utils;
 
-#[cfg(feature = "crypto-bls")]
 #[doc(inline)]
+#[cfg(feature = "crypto-bls")]
 pub use eigen_crypto_bls as crypto_bls;
 
-#[cfg(feature = "crypto-bn254")]
 #[doc(inline)]
+#[cfg(feature = "crypto-bn254")]
 pub use eigen_crypto_bn254 as crypto_bn254;
 
-#[cfg(feature = "signer")]
 #[doc(inline)]
+#[cfg(feature = "signer")]
 pub use eigen_signer as signer;
 
-#[cfg(feature = "logging")]
 #[doc(inline)]
+#[cfg(feature = "logging")]
 pub use eigen_logging as logging;
 
-#[cfg(feature = "metrics")]
 #[doc(inline)]
+#[cfg(feature = "metrics")]
 pub use eigen_metrics as metrics;
 
 /* ------------------------------------- Client Re-exports ------------------------------------- */
 
-#[cfg(feature = "client-avsregistry")]
 #[doc(inline)]
+#[cfg(feature = "client-avsregistry")]
 pub use eigen_client_avsregistry as client_avsregistry;
 
-#[cfg(feature = "client-elcontracts")]
 #[doc(inline)]
+#[cfg(feature = "client-elcontracts")]
 pub use eigen_client_elcontracts as client_elcontracts;
 
-#[cfg(feature = "client-eth")]
 #[doc(inline)]
+#[cfg(feature = "client-eth")]
 pub use eigen_client_eth as client_eth;
 
-#[cfg(feature = "client-fireblocks")]
 #[doc(inline)]
+#[cfg(feature = "client-fireblocks")]
 pub use eigen_client_fireblocks as client_fireblocks;
 
 /* ------------------------------------- Services Re-exports ------------------------------------- */
 
-#[cfg(feature = "services-avsregistry")]
 #[doc(inline)]
+#[cfg(feature = "services-avsregistry")]
 pub use eigen_services_avsregistry as services_avsregistry;
 
-#[cfg(feature = "services-blsaggregation")]
 #[doc(inline)]
+#[cfg(feature = "services-blsaggregation")]
 pub use eigen_services_blsaggregation as services_blsaggregation;
 
-#[cfg(feature = "services-operatorsinfo")]
 #[doc(inline)]
+#[cfg(feature = "services-operatorsinfo")]
 pub use eigen_services_operatorsinfo as services_operatorsinfo;
 
 /* ------------------------------------ Node API Re-export ------------------------------------ */
 
-#[cfg(feature = "nodeapi")]
 #[doc(inline)]
+#[cfg(feature = "nodeapi")]
 pub use eigen_nodeapi as nodeapi;
 
 /* ------------------------------------ Testing Utils Re-export -------------------------------- */
 
-#[cfg(feature = "testing-utils")]
 #[doc(inline)]
+#[cfg(feature = "testing-utils")]
 pub use eigen_testing_utils as testing_utils;
 
 /* ------------------------------------ Metrics Collectors Re-exports -------------------------- */
 
-#[cfg(feature = "metrics-collectors-economic")]
 #[doc(inline)]
+#[cfg(feature = "metrics-collectors-economic")]
 pub use eigen_metrics_collectors_economic as metrics_collectors_economic;
 
-#[cfg(feature = "metrics-collectors-rpc-calls")]
 #[doc(inline)]
+#[cfg(feature = "metrics-collectors-rpc-calls")]
 pub use eigen_metrics_collectors_rpc_calls as metrics_collectors_rpc_calls;
 
 /* ------------------------------------ Common Utilities Re-exports -------------------------- */


### PR DESCRIPTION
Fixes #

### What Changed?

This PR updates the `make docs` target to inline the documentation of `eigensdk` submodules. The directives to inline the docs were already there, but `docs.rs` wasn't using them since features weren't enabled. To enable them we need some tweaks specified in its documentation: https://docs.rs/about/builds

Commit 898cd53ab083e1331f0df69b4c426f7bdc371103 includes metadata for `docs.rs` in the `eigensdk` crate's manifest. This change should be replicated to other crates.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
