### PR TITLE
chore: apply cargo doc metadata to crates

### DIFF
--- a/crates/chainio/clients/avsregistry/Cargo.toml
+++ b/crates/chainio/clients/avsregistry/Cargo.toml
@@ -8,6 +8,12 @@ rust-version.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy.workspace = true
 async-trait.workspace = true

--- a/crates/chainio/clients/elcontracts/Cargo.toml
+++ b/crates/chainio/clients/elcontracts/Cargo.toml
@@ -8,6 +8,12 @@ rust-version.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy.workspace = true
 eigen-crypto-bls.workspace = true

--- a/crates/chainio/clients/eth/Cargo.toml
+++ b/crates/chainio/clients/eth/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 description = "eigen layer instrumented client "
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy.workspace = true
 async-trait.workspace = true

--- a/crates/chainio/clients/fireblocks/Cargo.toml
+++ b/crates/chainio/clients/fireblocks/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 description = "fireblocks support for eigenlayer"
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 #alloy
 alloy.workspace = true

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 description = "Common functions for EigenLayer SDK"
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy.workspace = true
 url.workspace = true

--- a/crates/crypto/bls/Cargo.toml
+++ b/crates/crypto/bls/Cargo.toml
@@ -8,6 +8,12 @@ rust-version.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 ark-bn254.workspace = true
 ark-ff.workspace = true

--- a/crates/crypto/bn254/Cargo.toml
+++ b/crates/crypto/bn254/Cargo.toml
@@ -8,6 +8,12 @@ rust-version.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 ark-bn254.workspace = true
 ark-ec.workspace = true

--- a/crates/crypto/ecdsa/Cargo.toml
+++ b/crates/crypto/ecdsa/Cargo.toml
@@ -5,5 +5,11 @@ edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 eth-keystore = "0.5.0"

--- a/crates/eigen-cli/Cargo.toml
+++ b/crates/eigen-cli/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 description = "eigen layer cli"
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy.workspace = true
 ark-ec.workspace = true

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 description = "logging utilities"
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 ctor = "0.2.8"
 once_cell.workspace = true

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 description ="prometheus server for metrics"
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 eigen-logging.workspace = true
 metrics.workspace = true

--- a/crates/metrics/collectors/economic/Cargo.toml
+++ b/crates/metrics/collectors/economic/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 description = "eigenlayer economic metrics"
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy.workspace = true
 eigen-logging.workspace = true

--- a/crates/metrics/collectors/rpc_calls/Cargo.toml
+++ b/crates/metrics/collectors/rpc_calls/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 description = "eigenlayer rpc calls metrics"
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 eigen-logging.workspace = true
 metrics.workspace = true

--- a/crates/nodeapi/Cargo.toml
+++ b/crates/nodeapi/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 license-file.workspace = true
 description = "eigenlayer nodeapi implementation"
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 serde_json.workspace =true
 ntex = { version = "2.0", features = ["tokio"] }

--- a/crates/services/avsregistry/Cargo.toml
+++ b/crates/services/avsregistry/Cargo.toml
@@ -8,6 +8,12 @@ rust-version.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy.workspace = true
 ark-bn254.workspace = true

--- a/crates/services/bls_aggregation/Cargo.toml
+++ b/crates/services/bls_aggregation/Cargo.toml
@@ -8,6 +8,12 @@ rust-version.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy.workspace = true
 ark-bn254.workspace = true

--- a/crates/services/operatorsinfo/Cargo.toml
+++ b/crates/services/operatorsinfo/Cargo.toml
@@ -8,6 +8,12 @@ rust-version.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy.workspace = true
 async-trait.workspace = true

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 description = "aws,keystore,web3,private_key signers"
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy.workspace =true 
 async-trait.workspace = true

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -8,6 +8,12 @@ rust-version.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 alloy.workspace = true
 ark-ff.workspace = true

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -7,6 +7,12 @@ repository.workspace = true
 description = "publicly exportable alloy bindings and utilities"
 license-file.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lib]
 doctest = false
 

--- a/tests/testing-utils/Cargo.toml
+++ b/tests/testing-utils/Cargo.toml
@@ -7,6 +7,12 @@ rust-version.workspace = true
 license-file.workspace = true
 repository.workspace = true
 
+# docs.rs-specific configuration
+# see https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
### What Changed?
This PR adds metadata for `docs.rs` in crates:

`avsregistry`, `elcontracts`, `eth`, `fireblocks`, `common`, `bls`, `bn254`, `ecdsa`, `eigen-cli`, `logging`, `metrics`, `economic`, `rpc_calls`, `nodeapi`, `avsregistry`, `bls_aggregation`, `operatorsinfo`, `signer`, `types`, `utils` and `testing-utils`

Fixes #440 

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
