### PR TITLE
fix: ignore integration tests crate when publishing

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -15,3 +15,8 @@ git_tag_name = "v{{ version }}"
 git_tag_enable = true
 git_release_enable = true
 git_release_draft = true
+
+# Integration test packages
+[[package]]
+name = "chainio-integration-test"
+release = false


### PR DESCRIPTION
Fixes #

### What Changed?

This PR updates the release-plz configuration file to ignore the `chainio-integration-test` crate when publishing a new release.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
