### PR TITLE
fix: specify version for testing-utils at workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,11 +78,7 @@ eigen-signer = { version = "0.5.0", path = "crates/signer/" }
 eigen-types = { version = "0.5.0", path = "crates/types/" }
 eigen-utils = { version = "0.5.0", path = "crates/utils/" }
 eigen-nodeapi = { version = "0.5.0", path = "crates/nodeapi/" }
-
-# Testing
-# We don't specify version due to:
-# https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
-eigen-testing-utils = { path = "tests/testing-utils" }
+eigen-testing-utils = { version = "0.5.0", path = "tests/testing-utils" }
 
 ark-bn254 = "0.5.0"
 ark-ec = "0.5.0"

--- a/crates/chainio/clients/avsregistry/Cargo.toml
+++ b/crates/chainio/clients/avsregistry/Cargo.toml
@@ -32,7 +32,9 @@ tracing.workspace = true
 workspace = true
 
 [dev-dependencies]
-eigen-testing-utils.workspace = true
+# We don't use workspace due to:
+# https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
+eigen-testing-utils = { path = "../../../../tests/testing-utils" }
 
 hex = "0.4.3"
 once_cell.workspace = true

--- a/crates/chainio/clients/elcontracts/Cargo.toml
+++ b/crates/chainio/clients/elcontracts/Cargo.toml
@@ -25,7 +25,9 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-eigen-testing-utils.workspace = true
+# We don't use workspace due to:
+# https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
+eigen-testing-utils = { path = "../../../../tests/testing-utils" }
 
 once_cell.workspace = true
 tokio.workspace = true

--- a/crates/chainio/clients/eth/Cargo.toml
+++ b/crates/chainio/clients/eth/Cargo.toml
@@ -23,9 +23,9 @@ thiserror.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-eigen-testing-utils.workspace = true
 # We don't use workspace due to:
 # https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
+eigen-testing-utils = { path = "../../../../tests/testing-utils" }
 eigen-common = { path = "../../../common" }
 
 once_cell.workspace = true

--- a/crates/crypto/bls/Cargo.toml
+++ b/crates/crypto/bls/Cargo.toml
@@ -27,7 +27,9 @@ eigen-crypto-bn254.workspace = true
 eigen-utils.workspace = true
 
 [dev-dependencies]
-eigen-testing-utils.workspace = true
+# We don't use workspace due to:
+# https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
+eigen-testing-utils = { path = "../../../tests/testing-utils" }
 
 rand = "0.8.4"
 tokio = { workspace = true, features = ["full"] }

--- a/crates/eigen-cli/Cargo.toml
+++ b/crates/eigen-cli/Cargo.toml
@@ -38,7 +38,9 @@ uuid.workspace = true
 
 
 [dev-dependencies]
-eigen-testing-utils.workspace = true
+# We don't use workspace due to:
+# https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
+eigen-testing-utils = { path = "../../tests/testing-utils" }
 
 rstest.workspace = true
 tempfile.workspace = true

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -20,9 +20,9 @@ metrics-exporter-prometheus.workspace = true
 metrics-util = "0.19.0"
 
 [dev-dependencies]
-eigen-testing-utils.workspace = true
 # We don't use workspace due to:
 # https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
+eigen-testing-utils = { path = "../../tests/testing-utils" }
 eigen-metrics-collectors-rpc-calls = { path = "./collectors/rpc_calls" }
 eigen-metrics-collectors-economic = { path = "./collectors/economic" }
 eigen-client-elcontracts = { path = "../chainio/clients/elcontracts" }

--- a/crates/metrics/collectors/economic/Cargo.toml
+++ b/crates/metrics/collectors/economic/Cargo.toml
@@ -24,6 +24,8 @@ metrics.workspace = true
 num-bigint.workspace = true
 
 [dev-dependencies]
-eigen-testing-utils.workspace = true
+# We don't use workspace due to:
+# https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
+eigen-testing-utils = { path = "../../../../tests/testing-utils" }
 
 tokio.workspace = true

--- a/crates/services/avsregistry/Cargo.toml
+++ b/crates/services/avsregistry/Cargo.toml
@@ -26,7 +26,9 @@ eigen-types.workspace = true
 eigen-utils.workspace = true
 
 [dev-dependencies]
-eigen-testing-utils.workspace = true
+# We don't use workspace due to:
+# https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
+eigen-testing-utils = { path = "../../../tests/testing-utils" }
 
 hex.workspace = true
 tokio.workspace = true

--- a/crates/services/bls_aggregation/Cargo.toml
+++ b/crates/services/bls_aggregation/Cargo.toml
@@ -33,9 +33,9 @@ serde.workspace = true
 simple-mermaid = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
-eigen-testing-utils.workspace = true
 # We don't use workspace due to:
 # https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
+eigen-testing-utils = { path = "../../../tests/testing-utils" }
 eigen-logging = { path = "../../logging" }
 eigen-utils = { path = "../../utils" }
 eigen-client-elcontracts = { path = "../../chainio/clients/elcontracts" }

--- a/crates/services/operatorsinfo/Cargo.toml
+++ b/crates/services/operatorsinfo/Cargo.toml
@@ -31,9 +31,9 @@ futures.workspace = true
 eyre.workspace = true
 
 [dev-dependencies]
-eigen-testing-utils.workspace = true
 # We don't use workspace due to:
 # https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
+eigen-testing-utils = { path = "../../../tests/testing-utils" }
 eigen-logging = { path = "../../logging" }
 eigen-client-elcontracts = { path = "../../chainio/clients/elcontracts" }
 

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -23,7 +23,9 @@ thiserror.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-eigen-testing-utils.workspace = true
+# We don't use workspace due to:
+# https://github.com/rust-lang/cargo/issues/4242#issuecomment-2578428685
+eigen-testing-utils = { path = "../../tests/testing-utils" }
 
 aws-config.workspace = true
 testcontainers.workspace = true


### PR DESCRIPTION
### What Changed?

We need the version to be specified for `eigensdk` crate, but not for the rest. This PR changes the workspace dep to have a version again, but the rest of the crates override it to have a path only.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
