### PR TITLE
refactor(v2): use `ws_rpc_url` from config instead of passing it as a parameter in Aggregator

### DIFF
--- a/crates/aggregator/src/lib.rs
+++ b/crates/aggregator/src/lib.rs
@@ -113,10 +113,6 @@ impl<TP: TaskProcessor + Send + Sync + 'static + Clone> Aggregator<TP> {
     /// - process_tasks: receives tasks from the log and processes them
     /// - process_aggregated_signatures: processes the aggregated signatures
     ///
-    /// # Arguments
-    ///
-    /// * `ws_rpc_url` - The websocket RPC URL
-    ///
     /// # Returns
     ///
     /// * `Result<(), AggregatorError>` - The result of the operation
@@ -133,11 +129,10 @@ impl<TP: TaskProcessor + Send + Sync + 'static + Clone> Aggregator<TP> {
             task_processor.clone(),
             service_handle.clone(),
         ));
-        let task_processor = self.task_processor.clone();
 
         let process_handle = tokio::spawn(Self::process_tasks(
             self.ws_rpc_url,
-            self.task_processor,
+            task_processor.clone(),
             service_handle,
         ));
         let aggregate_handle = tokio::spawn(Self::process_aggregated_signatures(

--- a/crates/aggregator/src/lib.rs
+++ b/crates/aggregator/src/lib.rs
@@ -49,6 +49,7 @@ pub struct Aggregator<TP> {
     task_processor: Arc<Mutex<TP>>,
     service_handle: ServiceHandle,
     aggregated_response_receiver: AggregateReceiver,
+    ws_rpc_url: String,
 }
 
 impl<TP: TaskProcessor + Send + Sync + 'static + Clone> Aggregator<TP> {
@@ -101,6 +102,7 @@ impl<TP: TaskProcessor + Send + Sync + 'static + Clone> Aggregator<TP> {
             task_processor: Arc::new(Mutex::new(task_processor)),
             service_handle,
             aggregated_response_receiver,
+            ws_rpc_url: config.ws_rpc_url,
         })
     }
 
@@ -118,7 +120,7 @@ impl<TP: TaskProcessor + Send + Sync + 'static + Clone> Aggregator<TP> {
     /// # Returns
     ///
     /// * `Result<(), AggregatorError>` - The result of the operation
-    pub async fn start(self, ws_rpc_url: String) -> Result<(), AggregatorError> {
+    pub async fn start(self) -> Result<(), AggregatorError> {
         info!("Starting aggregator");
 
         let task_processor = self.task_processor.clone();
@@ -134,8 +136,8 @@ impl<TP: TaskProcessor + Send + Sync + 'static + Clone> Aggregator<TP> {
         let task_processor = self.task_processor.clone();
 
         let process_handle = tokio::spawn(Self::process_tasks(
-            ws_rpc_url,
-            task_processor.clone(),
+            self.ws_rpc_url,
+            self.task_processor,
             service_handle,
         ));
         let aggregate_handle = tokio::spawn(Self::process_aggregated_signatures(

--- a/examples/aggregator/examples/aggregator.rs
+++ b/examples/aggregator/examples/aggregator.rs
@@ -221,7 +221,7 @@ async fn main() {
     let aggregator = Aggregator::new(config, processor).await.unwrap();
 
     // 6. Start the aggregator in the background
-    let aggregator_handle = tokio::spawn(aggregator.start(ws_rpc.clone()));
+    let aggregator_handle = tokio::spawn(aggregator.start());
 
     // Wait for the aggregator to initialize
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;


### PR DESCRIPTION
### What Changed?

This PR removes the parameter that the `start()` function receives since we already have this value in `AggregatorConfig`.
### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
