### PR TITLE
feat: add socket to OperatorInfo struct (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,48 @@ Alternate implementation which directly queries from middleware using view call 
         .unwrap();
   ```
 
+* Added field `socket` to `OperatorInfo` and a method `get_operator_socket` to retrieve the socket from the `AvsRegistryServiceChainCaller` in PR [463](https://github.com/Layr-Labs/eigensdk-rs/pull/463).
+
+  ```rust
+    // BEFORE
+    let info = self.get_operator_info(*operator.operatorId).await?;
+    let stake_per_quorum = HashMap::new();
+    let avs_state = operators_avs_state
+        .entry(FixedBytes(*operator.operatorId))
+        .or_insert_with(|| OperatorAvsState {
+            operator_id: operator.operatorId,
+            operator_info: OperatorInfo {
+                pub_keys: Some(info),
+            },
+            stake_per_quorum,
+            block_num: block_num.into(),
+        });
+    avs_state
+        .stake_per_quorum
+        .insert(*quorum_num, U256::from(operator.stake));
+
+    // AFTER
+    // Now we use the new method to retrieve the socket in `get_operators_avs_state_at_block`
+    // And use the value in the new field `socket` in `OperatorInfo`
+    let socket = self.get_operator_socket(*operator.operatorId).await?;
+    let info = self.get_operator_info(*operator.operatorId).await?;
+    let stake_per_quorum = HashMap::new();
+    let avs_state = operators_avs_state
+        .entry(FixedBytes(*operator.operatorId))
+        .or_insert_with(|| OperatorAvsState {
+            operator_id: operator.operatorId,
+            operator_info: OperatorInfo {
+                pub_keys: Some(info),
+                socket: Some(socket),
+            },
+            stake_per_quorum,
+            block_num: block_num.into(),
+        });
+    avs_state
+        .stake_per_quorum
+        .insert(*quorum_num, U256::from(operator.stake));
+  ```
+
 ### Deprecated ⚠️
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Those changes in added, changed or breaking changes, should include usage exampl
 
 ### Added 🎉
 
+* Added a method `get_operator_socket` to retrieve the socket from the `AvsRegistryServiceChainCaller` in PR [464](https://github.com/Layr-Labs/eigensdk-rs/pull/464).
+
+  ```rust
+    let socket = self.get_operator_socket(*operator.operatorId).await.unwrap();
+  ```
+
 * Bump alloy to 0.13 and MSRV to 1.81 in PR [419](https://github.com/Layr-Labs/eigensdk-rs/pull/419).
 
 ### Breaking Changes 🛠
@@ -100,7 +106,7 @@ Alternate implementation which directly queries from middleware using view call 
         .unwrap();
   ```
 
-* Added field `socket` to `OperatorInfo` and a method `get_operator_socket` to retrieve the socket from the `AvsRegistryServiceChainCaller` in PR [463](https://github.com/Layr-Labs/eigensdk-rs/pull/463).
+* Added field `socket` to `OperatorInfo` in PR [464](https://github.com/Layr-Labs/eigensdk-rs/pull/464)
 
   ```rust
     // BEFORE

--- a/crates/services/avsregistry/src/chaincaller.rs
+++ b/crates/services/avsregistry/src/chaincaller.rs
@@ -168,6 +168,15 @@ impl<R: AvsRegistryReader, S: OperatorInfoService> AvsRegistryServiceChainCaller
             .ok_or(AvsRegistryError::GetOperatorInfo)
     }
 
+    /// Returns the operator socket for the given operator id
+    ///
+    /// # Arguments
+    ///
+    /// * `operator_id` - The operator id
+    ///
+    /// # Returns
+    ///
+    /// The operator socket
     async fn get_operator_socket(&self, operator_id: [u8; 32]) -> Result<String, AvsRegistryError> {
         let operator_addr = self.avs_registry.get_operator_from_id(operator_id).await?;
         self.operators_info_service

--- a/crates/services/avsregistry/src/chaincaller.rs
+++ b/crates/services/avsregistry/src/chaincaller.rs
@@ -59,6 +59,7 @@ impl<R: AvsRegistryReader + Sync, S: OperatorInfoService + Sync> AvsRegistryServ
         for (quorum_id, quorum_num) in quorum_nums.iter().enumerate() {
             for operator in &operators_stakes_in_quorums[quorum_id] {
                 let info = self.get_operator_info(*operator.operatorId).await?;
+                let socket = self.get_operator_socket(*operator.operatorId).await?;
                 let stake_per_quorum = HashMap::new();
                 let avs_state = operators_avs_state
                     .entry(FixedBytes(*operator.operatorId))
@@ -66,6 +67,7 @@ impl<R: AvsRegistryReader + Sync, S: OperatorInfoService + Sync> AvsRegistryServ
                         operator_id: operator.operatorId,
                         operator_info: OperatorInfo {
                             pub_keys: Some(info),
+                            socket: Some(socket),
                         },
                         stake_per_quorum,
                         block_num: block_num.into(),
@@ -165,6 +167,15 @@ impl<R: AvsRegistryReader, S: OperatorInfoService> AvsRegistryServiceChainCaller
             .unwrap_or(None)
             .ok_or(AvsRegistryError::GetOperatorInfo)
     }
+
+    async fn get_operator_socket(&self, operator_id: [u8; 32]) -> Result<String, AvsRegistryError> {
+        let operator_addr = self.avs_registry.get_operator_from_id(operator_id).await?;
+        self.operators_info_service
+            .get_operator_socket(operator_addr)
+            .await
+            .unwrap_or(None)
+            .ok_or(AvsRegistryError::GetOperatorInfo)
+    }
 }
 
 #[cfg(test)]
@@ -232,7 +243,10 @@ mod tests {
     ) -> AvsRegistryServiceChainCaller<FakeAvsRegistryReader, FakeOperatorInfoService> {
         let operator_address = Address::from_str(operator_address).unwrap();
         let avs_registry = FakeAvsRegistryReader::new(test_operator.clone(), operator_address);
-        let operator_info_service = FakeOperatorInfoService::new(test_operator.bls_keypair.clone());
+        let operator_info_service = FakeOperatorInfoService::new(
+            test_operator.bls_keypair.clone(),
+            Some(String::from("test_socket")),
+        );
         AvsRegistryServiceChainCaller::new(avs_registry, operator_info_service)
     }
 
@@ -295,6 +309,7 @@ mod tests {
             operator_id: test_operator.operator_id,
             operator_info: OperatorInfo {
                 pub_keys: Some(OperatorPubKeys::from(test_operator.bls_keypair)),
+                socket: Some(String::from("test_socket")),
             },
             stake_per_quorum: test_operator.stake_per_quorum,
             block_num: test_data.input.block_num.into(),

--- a/crates/services/avsregistry/src/fake_avs_registry_service.rs
+++ b/crates/services/avsregistry/src/fake_avs_registry_service.rs
@@ -41,6 +41,7 @@ impl FakeAvsRegistryService {
                 operator_id: op.operator_id,
                 operator_info: OperatorInfo {
                     pub_keys: Some(OperatorPubKeys::from(op.bls_keypair)),
+                    socket: None,
                 },
                 block_num: block_number.into(),
                 stake_per_quorum: op.stake_per_quorum,

--- a/crates/services/avsregistry/src/lib.rs
+++ b/crates/services/avsregistry/src/lib.rs
@@ -54,7 +54,7 @@
 //!#     };
 //!#     let operator_address = Address::from(FIRST_ADDRESS);
 //!#     let avs_registry = FakeAvsRegistryReader::new(test_operator.clone(), operator_address);
-//!#     let operator_info_service = FakeOperatorInfoService::new(test_operator.bls_keypair.clone());
+//!#     let operator_info_service = FakeOperatorInfoService::new(test_operator.bls_keypair.clone(), Some(String::from("test_socket")));
 //!#
 //!     let avs_registry_service =
 //!         AvsRegistryServiceChainCaller::new(avs_registry, operator_info_service);
@@ -89,7 +89,7 @@
 //!#     };
 //!#     let operator_address = Address::from(FIRST_ADDRESS);
 //!#     let avs_registry = FakeAvsRegistryReader::new(test_operator.clone(), operator_address);
-//!#     let operator_info_service = FakeOperatorInfoService::new(test_operator.bls_keypair.clone());
+//!#     let operator_info_service = FakeOperatorInfoService::new(test_operator.bls_keypair.clone(), Some(String::from("test_socket")));
 //!#
 //!#     let avs_registry_service =
 //!#         AvsRegistryServiceChainCaller::new(avs_registry, operator_info_service);
@@ -128,7 +128,7 @@
 //!#     };
 //!#     let operator_address = Address::from(FIRST_ADDRESS);
 //!#     let avs_registry = FakeAvsRegistryReader::new(test_operator.clone(), operator_address);
-//!#     let operator_info_service = FakeOperatorInfoService::new(test_operator.bls_keypair.clone());
+//!#     let operator_info_service = FakeOperatorInfoService::new(test_operator.bls_keypair.clone(), Some(String::from("test_socket")));
 //!#
 //!#     let avs_registry_service =
 //!#         AvsRegistryServiceChainCaller::new(avs_registry, operator_info_service);
@@ -168,7 +168,7 @@
 //!#     };
 //!#     let operator_address = Address::from(FIRST_ADDRESS);
 //!#     let avs_registry = FakeAvsRegistryReader::new(test_operator.clone(), operator_address);
-//!#     let operator_info_service = FakeOperatorInfoService::new(test_operator.bls_keypair.clone());
+//!#     let operator_info_service = FakeOperatorInfoService::new(test_operator.bls_keypair.clone(), Some(String::from("test_socket")));
 //!#
 //!#     let avs_registry_service =
 //!#         AvsRegistryServiceChainCaller::new(avs_registry, operator_info_service);

--- a/crates/services/operatorsinfo/src/fake_operator_info.rs
+++ b/crates/services/operatorsinfo/src/fake_operator_info.rs
@@ -7,17 +7,16 @@ use crate::{operator_info::OperatorInfoService, operatorsinfo_inmemory::Operator
 
 /// A fake implementation of the `OperatorInfoService` trait that can be used for testing or debug purposes.
 pub struct FakeOperatorInfoService {
-    pub pubkeys: OperatorInfo,
-    pub socket: String,
+    pub operator_info: OperatorInfo,
 }
 
 impl FakeOperatorInfoService {
-    pub fn new(pubkeys: BlsKeyPair) -> Self {
+    pub fn new(pubkeys: BlsKeyPair, socket: Option<String>) -> Self {
         Self {
-            pubkeys: OperatorInfo {
+            operator_info: OperatorInfo {
                 pub_keys: Some(OperatorPubKeys::from(pubkeys)),
+                socket,
             },
-            socket: String::default(),
         }
     }
 }
@@ -28,13 +27,13 @@ impl OperatorInfoService for FakeOperatorInfoService {
         &self,
         _address: Address,
     ) -> Result<Option<OperatorPubKeys>, OperatorInfoServiceError> {
-        Ok(self.pubkeys.pub_keys.clone())
+        Ok(self.operator_info.pub_keys.clone())
     }
 
     async fn get_operator_socket(
         &self,
         _address: Address,
     ) -> Result<Option<String>, OperatorInfoServiceError> {
-        Ok(Some(self.socket.clone()))
+        Ok(self.operator_info.socket.clone())
     }
 }

--- a/crates/types/src/operator.rs
+++ b/crates/types/src/operator.rs
@@ -136,6 +136,7 @@ pub type QuorumNum = u8;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OperatorInfo {
     pub pub_keys: Option<OperatorPubKeys>,
+    pub socket: Option<Socket>,
 }
 
 pub fn operator_id_from_g1_pub_key(pub_key: BlsG1Point) -> Result<OperatorId, OperatorTypesError> {


### PR DESCRIPTION
### What Changed?
This PR adds a missing field `socket` to `OperatorInfo`. We also added a method `get_operator_socket()` in `AvsRegistryServiceChainCaller`.

The new method is used in `get_operators_avs_state_at_block()`, now you can obtain the operator socket value that is inside the `OperatorInfo`.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it

Fixes #

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
