### PR TITLE
refactor(v2): small change in task generator trait

### DIFF
--- a/crates/task-generator/src/lib.rs
+++ b/crates/task-generator/src/lib.rs
@@ -154,8 +154,8 @@ impl<I, TM, T, P, N, Input> TaskGenerator<I, TM, T, P, N, Input>
 where
     TM: TaskManagerContract<Input, T, P, N> + Send + Sync,
     T: Transport + Clone + Send + Sync,
-    P: Provider<T, N> + Send + Sync,
-    N: Network + Send + Sync,
+    P: Provider<T, N>,
+    N: Network,
 {
     /// Run the task generator
     /// This will create N tasks, where N is the number of items in the iterator
@@ -172,9 +172,6 @@ where
         for input in self.iter {
             self.task_manager
                 .create_new_task(input, self.quorum_threshold, self.quorums.clone())
-                .send()
-                .await?
-                .get_receipt()
                 .await?;
             sleep(self.interval).await;
         }

--- a/crates/task-generator/src/task_manager.rs
+++ b/crates/task-generator/src/task_manager.rs
@@ -1,11 +1,11 @@
-use alloy::{contract::SolCallBuilder, sol_types::SolCall};
+use alloy::network::Network;
 use eigen_types::operator::{QuorumNum, QuorumThresholdPercentage};
+use std::future::Future;
+
+use crate::error::TaskGeneratorError;
 
 /// Task manager contract trait
-pub trait TaskManagerContract<Input, T, P, N: alloy::network::Network> {
-    /// Call type that will be used to create a new task
-    type Call: SolCall;
-
+pub trait TaskManagerContract<Input, T, P, N: Network> {
     /// Create a new task
     ///
     /// # Arguments
@@ -16,11 +16,11 @@ pub trait TaskManagerContract<Input, T, P, N: alloy::network::Network> {
     ///
     /// # Returns
     ///
-    /// * `SolCallBuilder<T, &P, Self::Call, N>` - The call builder for the task
+    /// * `Result<N::ReceiptResponse, TaskGeneratorError>` - The result of the task
     fn create_new_task(
         &self,
         input: Input,
         quorum_threshold: QuorumThresholdPercentage,
         quorums: Vec<QuorumNum>,
-    ) -> SolCallBuilder<T, &P, Self::Call, N>;
+    ) -> impl Future<Output = Result<N::ReceiptResponse, TaskGeneratorError>> + Send;
 }

--- a/examples/task-generator/src/main.rs
+++ b/examples/task-generator/src/main.rs
@@ -3,17 +3,16 @@ use alloy::{
     network::Network,
 };
 use alloy::{
-    contract::SolCallBuilder,
     network::EthereumWallet,
     primitives::{Address, U256},
     providers::ProviderBuilder,
     signers::local::PrivateKeySigner,
     transports::http::reqwest::Url,
 };
-use bindings::iincrediblesquaringtaskmanager::IIncredibleSquaringTaskManager::{
-    createNewTaskCall, IIncredibleSquaringTaskManagerInstance,
+use bindings::iincrediblesquaringtaskmanager::IIncredibleSquaringTaskManager::IIncredibleSquaringTaskManagerInstance;
+use eigen_task_generator::{
+    error::TaskGeneratorError, task_manager::TaskManagerContract, TaskGeneratorBuilder,
 };
-use eigen_task_generator::{task_manager::TaskManagerContract, TaskGeneratorBuilder};
 use eigen_types::operator::{QuorumNum, QuorumThresholdPercentage};
 use std::{str::FromStr, time::Duration};
 
@@ -30,19 +29,22 @@ use std::{str::FromStr, time::Duration};
 // impl<T, P, N> TaskManagerContract<U256, T, P, N> for TaskManagerWrapper<T, P, N> { ... }
 impl<T, P, N> TaskManagerContract<U256, T, P, N> for IIncredibleSquaringTaskManagerInstance<T, P, N>
 where
-    T: Transport + Clone,
+    T: Transport + Clone + Send + Sync,
     P: Provider<T, N>,
     N: Network,
 {
-    type Call = createNewTaskCall;
-
-    fn create_new_task(
+    async fn create_new_task(
         &self,
         input: U256,
         quorum_threshold: QuorumThresholdPercentage,
         quorums: Vec<QuorumNum>,
-    ) -> SolCallBuilder<T, &P, Self::Call, N> {
-        self.createNewTask(input, quorum_threshold.into(), quorums.into())
+    ) -> Result<N::ReceiptResponse, TaskGeneratorError> {
+        Ok(self
+            .createNewTask(input, quorum_threshold.into(), quorums.into())
+            .send()
+            .await?
+            .get_receipt()
+            .await?)
     }
 }
 


### PR DESCRIPTION
### What changed
This PR updates the `TaskManagerContract` trait by changing the signature of `create_new_task`:

- Removes the `SolCall` type.
- `create_new_task` now returns an `impl Future<Output = Result<N::ReceiptResponse, TaskGeneratorError>> + Send`. Users no need to use the `SolCall` from the bindings. Now they need to call `.send()` and `.get_receipt()`.
- Updates the example usage

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
