### PR TITLE
chore: set doctest to false for bindings in IS example

### DIFF
--- a/examples/incredible-squaring/Cargo.toml
+++ b/examples/incredible-squaring/Cargo.toml
@@ -29,6 +29,9 @@ tracing.workspace = true
 serde_json.workspace = true
 ark-ec.workspace = true
 
+[lib]
+doctest = false
+
 [[bin]]
 name = "incredible-squaring-aggregator"
 path = "src/bin/aggregator.rs"


### PR DESCRIPTION
### What Changed?

This PR disables doctests for the `incredible-squaring` example bindings to fix test failures.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
