### PR TITLE
feat(v2): remove generics from `TaskManagerContract` trait

### DIFF
--- a/crates/challenger/src/challenger_processor.rs
+++ b/crates/challenger/src/challenger_processor.rs
@@ -1,10 +1,6 @@
 use crate::{challenger::ChallengerTaskProcessor, error::ChallengerError};
 use alloy::dyn_abi::SolType;
-use alloy::{
-    contract::private::{Provider, Transport},
-    network::Network,
-    sol_types::SolValue,
-};
+use alloy::sol_types::SolValue;
 
 use eigen_task_processor::task_manager::TaskManagerContract;
 use eigen_task_processor::task_response_metadata_sol::TaskResponseMetadataSol;
@@ -14,12 +10,9 @@ use std::collections::HashMap;
 use tracing::error;
 
 #[derive(Debug)]
-pub struct IndexingChallengerProcessor<TM, T, P, N, F>
+pub struct IndexingChallengerProcessor<TM, F>
 where
-    TM: TaskManagerContract<T, P, N> + Send + Sync + 'static + Clone,
-    T: Transport + Clone + Send + Sync,
-    P: Provider<T, N>,
-    N: Network,
+    TM: TaskManagerContract + Send + Sync + 'static + Clone,
     F: Fn(Task<TM::Input>, TaskResponse<TM::Output>) -> Result<bool, ChallengerError> + Send + Sync,
 {
     task_manager: TM,
@@ -27,14 +20,11 @@ where
     is_response_correct: F,
 }
 
-impl<TM, T, P, N, F> ChallengerTaskProcessor for IndexingChallengerProcessor<TM, T, P, N, F>
+impl<TM, F> ChallengerTaskProcessor for IndexingChallengerProcessor<TM, F>
 where
-    TM: TaskManagerContract<T, P, N> + Send + Sync + 'static + Clone,
+    TM: TaskManagerContract + Send + Sync + 'static + Clone,
     TM::Input: From<<<TM::Input as SolValue>::SolType as SolType>::RustType>,
     TM::Output: From<<<TM::Output as SolValue>::SolType as SolType>::RustType>,
-    T: Transport + Clone + Send + Sync,
-    P: Provider<T, N>,
-    N: Network,
     F: Fn(Task<TM::Input>, TaskResponse<TM::Output>) -> Result<bool, ChallengerError> + Send + Sync,
 {
     type NewTaskEvent = TM::NewTaskEvent;
@@ -83,14 +73,11 @@ where
     }
 }
 
-impl<TM, T, P, N, F> IndexingChallengerProcessor<TM, T, P, N, F>
+impl<TM, F> IndexingChallengerProcessor<TM, F>
 where
-    TM: TaskManagerContract<T, P, N> + Send + Sync + 'static + Clone,
+    TM: TaskManagerContract + Send + Sync + 'static + Clone,
     TM::Input: From<<<TM::Input as SolValue>::SolType as SolType>::RustType>,
     TM::Output: From<<<TM::Output as SolValue>::SolType as SolType>::RustType>,
-    T: Transport + Clone + Send + Sync,
-    P: Provider<T, N>,
-    N: Network,
     F: Fn(Task<TM::Input>, TaskResponse<TM::Output>) -> Result<bool, ChallengerError> + Send + Sync,
 {
     pub fn new(task_manager: TM, is_response_correct: F) -> Self {

--- a/crates/task-processor/src/lib.rs
+++ b/crates/task-processor/src/lib.rs
@@ -1,10 +1,6 @@
 //! Task manager
 
 use alloy::primitives::B256;
-use alloy::{
-    contract::private::{Provider, Transport},
-    network::Network,
-};
 use ark_ec::AffineRepr;
 use eigen_crypto_bls::{convert_to_g1_point, convert_to_g2_point};
 use eigen_services_blsaggregation::{
@@ -43,12 +39,9 @@ type TaskResponsesMap<O> = HashMap<u32, HashMap<TaskResponseDigest, TaskResponse
 
 /// Indexing task processor
 #[derive(Debug, Clone)]
-pub struct IndexingTaskProcessor<TM, T, P, N>
+pub struct IndexingTaskProcessor<TM>
 where
-    TM: TaskManagerContract<T, P, N> + Debug + Send + Sync + 'static + Clone,
-    T: Transport + Clone + Send + Sync + 'static,
-    P: Provider<T, N>,
-    N: Network,
+    TM: TaskManagerContract + Debug + Send + Sync + 'static + Clone,
 {
     /// Hashmap to store the created tasks
     tasks: Arc<Mutex<HashMap<u32, Task<TM::Input>>>>,
@@ -62,12 +55,9 @@ where
     task_window_duration: Duration,
 }
 
-impl<TM, T, P, N> IndexingTaskProcessor<TM, T, P, N>
+impl<TM> IndexingTaskProcessor<TM>
 where
-    TM: TaskManagerContract<T, P, N> + Debug + Send + Sync + 'static + Clone,
-    T: Transport + Clone + Send + Sync + 'static,
-    P: Provider<T, N>,
-    N: Network,
+    TM: TaskManagerContract + Debug + Send + Sync + 'static + Clone,
 {
     /// Create a new task processor
     ///
@@ -89,12 +79,9 @@ where
     }
 }
 
-impl<TM, T, P, N> TaskProcessor for IndexingTaskProcessor<TM, T, P, N>
+impl<TM> TaskProcessor for IndexingTaskProcessor<TM>
 where
-    TM: TaskManagerContract<T, P, N> + Debug + Send + Sync + 'static + Clone,
-    T: Transport + Clone + Send + Sync + 'static,
-    P: Provider<T, N>,
-    N: Network,
+    TM: TaskManagerContract + Debug + Send + Sync + 'static + Clone,
 {
     type NewTaskEvent = TM::NewTaskEvent;
 

--- a/crates/task-processor/src/task_manager.rs
+++ b/crates/task-processor/src/task_manager.rs
@@ -3,10 +3,7 @@ use std::{fmt::Debug, future::Future};
 use crate::{
     task::Task, task_response::TaskResponse, task_response_metadata_sol::TaskResponseMetadataSol,
 };
-use alloy::{
-    network::Network,
-    sol_types::{SolEvent, SolValue},
-};
+use alloy::sol_types::{SolEvent, SolValue};
 use eigen_types::operator::{QuorumNum, QuorumThresholdPercentage};
 use eigen_utils::slashing::middleware::iblssignaturechecker::IBLSSignatureCheckerTypes::NonSignerStakesAndSignature;
 use eigen_utils::slashing::middleware::iblssignaturechecker::BN254::G1Point;
@@ -21,7 +18,7 @@ pub fn box_error<E: core::error::Error + Send + 'static>(e: E) -> TaskManagerErr
 }
 
 /// Task manager contract trait. It wraps the contract's types and functions.
-pub trait TaskManagerContract<T, P, N: Network> {
+pub trait TaskManagerContract {
     /// Type for inputs of each task
     type Input: Clone + SolValue + Send + Sync + 'static + Debug;
 
@@ -68,7 +65,7 @@ pub trait TaskManagerContract<T, P, N: Network> {
         input: Self::Input,
         quorum_threshold: QuorumThresholdPercentage,
         quorums: Vec<QuorumNum>,
-    ) -> impl Future<Output = Result<N::ReceiptResponse, TaskManagerError>> + Send;
+    ) -> impl Future<Output = Result<(), TaskManagerError>> + Send;
 
     /// Raise challenge
     ///

--- a/crates/task-spammer/src/lib.rs
+++ b/crates/task-spammer/src/lib.rs
@@ -1,10 +1,6 @@
 //! This is a simple task generator that can be used to create tasks for the operators.
 //! For testing purposes.
 
-use alloy::{
-    contract::private::{Provider, Transport},
-    network::Network,
-};
 use eigen_task_processor::task_manager::TaskManagerContract;
 use eigen_types::operator::{QuorumNum, QuorumThresholdPercentage};
 use error::TaskSpammerError;
@@ -16,21 +12,17 @@ pub mod error;
 
 /// Task spammer builder
 #[derive(Debug)]
-pub struct TaskSpammerBuilder<I, TM, T, P, N> {
+pub struct TaskSpammerBuilder<I, TM> {
     iter: Option<I>,
     interval: Duration,
     quorum_threshold: Option<QuorumThresholdPercentage>,
     quorums: Option<Vec<QuorumNum>>,
     task_manager: TM,
-    _phantom: std::marker::PhantomData<(T, P, N)>,
 }
 
-impl<I, TM, T, P, N> TaskSpammerBuilder<I, TM, T, P, N>
+impl<I, TM> TaskSpammerBuilder<I, TM>
 where
-    TM: TaskManagerContract<T, P, N>,
-    T: Transport + Clone,
-    P: Provider<T, N>,
-    N: Network,
+    TM: TaskManagerContract,
 {
     /// Create a new task spammer builder
     ///
@@ -48,7 +40,6 @@ where
             quorum_threshold: None,
             quorums: None,
             task_manager,
-            _phantom: std::marker::PhantomData,
         }
     }
 
@@ -73,7 +64,6 @@ where
             quorum_threshold: self.quorum_threshold,
             quorums: self.quorums,
             task_manager: self.task_manager,
-            _phantom: std::marker::PhantomData,
         }
     }
 
@@ -117,7 +107,7 @@ where
     /// # Returns
     ///
     /// * `TaskSpammer` - The task spammer to be run
-    pub fn build(self) -> Result<TaskSpammer<I, TM, T, P, N>, TaskSpammerError> {
+    pub fn build(self) -> Result<TaskSpammer<I, TM>, TaskSpammerError> {
         Ok(TaskSpammer {
             iter: self.iter.ok_or(TaskSpammerError::IteratorNotSet)?,
             interval: self.interval,
@@ -126,28 +116,23 @@ where
                 .ok_or(TaskSpammerError::QuorumThresholdNotSet)?,
             quorums: self.quorums.ok_or(TaskSpammerError::QuorumNotSet)?,
             task_manager: self.task_manager,
-            _phantom: std::marker::PhantomData,
         })
     }
 }
 
 /// Task spammer struct
 #[derive(Debug)]
-pub struct TaskSpammer<I, TM, T, P, N> {
+pub struct TaskSpammer<I, TM> {
     iter: I,
     interval: Duration,
     quorum_threshold: QuorumThresholdPercentage,
     quorums: Vec<QuorumNum>,
     task_manager: TM,
-    _phantom: std::marker::PhantomData<(T, P, N)>,
 }
 
-impl<I, TM, T, P, N> TaskSpammer<I, TM, T, P, N>
+impl<I, TM> TaskSpammer<I, TM>
 where
-    TM: TaskManagerContract<T, P, N> + Send + Sync,
-    T: Transport + Clone + Send + Sync,
-    P: Provider<T, N>,
-    N: Network,
+    TM: TaskManagerContract + Send + Sync,
 {
     /// Run the task spammer
     /// This will create N tasks, where N is the number of items in the iterator

--- a/examples/incredible-squaring/src/lib.rs
+++ b/examples/incredible-squaring/src/lib.rs
@@ -40,7 +40,7 @@ pub mod bindings;
 // struct TaskManagerWrapper<T, P, N>(IncredibleSquaringTaskManagerInstance<T, P, N>);
 //
 // impl<T, P, N> TaskManagerContract<U256, T, P, N> for TaskManagerWrapper<T, P, N> { ... }
-impl<T, P, N> TaskManagerContract<T, P, N> for IncredibleSquaringTaskManagerInstance<T, P, N>
+impl<T, P, N> TaskManagerContract for IncredibleSquaringTaskManagerInstance<T, P, N>
 where
     T: Transport + Clone + Send + Sync,
     P: Provider<T, N>,
@@ -56,7 +56,7 @@ where
         input: U256,
         quorum_threshold: QuorumThresholdPercentage,
         quorums: Vec<QuorumNum>,
-    ) -> Result<N::ReceiptResponse, TaskManagerError> {
+    ) -> Result<(), TaskManagerError> {
         self.createNewTask(input, quorum_threshold.into(), quorums.into())
             .send()
             .await
@@ -64,6 +64,7 @@ where
             .get_receipt()
             .await
             .map_err(box_error)
+            .map(|_| ())
     }
 
     async fn respond_to_task(


### PR DESCRIPTION
Fixes #

### What Changed?

This PR removes three unneeded generic parameters from the `TaskManagerContract` trait.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
