### PR TITLE
feat(v2): simplify `TaskManagerContract` trait to store event selector only

### DIFF
--- a/crates/aggregator/src/lib.rs
+++ b/crates/aggregator/src/lib.rs
@@ -14,7 +14,7 @@ use alloy::primitives::Bytes;
 use alloy::providers::Provider;
 use alloy::providers::{ProviderBuilder, WsConnect};
 use alloy::rpc::types::{Filter, Log};
-use alloy::sol_types::{SolEvent, SolValue};
+use alloy::sol_types::SolValue;
 pub use config::AggregatorConfig;
 use eigen_client_avsregistry::reader::AvsRegistryChainReader;
 use eigen_common::get_ws_provider;
@@ -218,7 +218,7 @@ where
         service_handle: ServiceHandle,
     ) -> Result<(), AggregatorError> {
         let ws = WsConnect::new(ws_rpc_url.clone());
-        let filter = Filter::new().event_signature(TP::NewTaskEvent::SIGNATURE_HASH);
+        let filter = Filter::new().event_signature(TP::NEW_TASK_EVENT_SELECTOR);
         let provider = ProviderBuilder::new().on_ws(ws).await?;
 
         while let Some(log) = provider

--- a/crates/challenger/src/challenger.rs
+++ b/crates/challenger/src/challenger.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use alloy::sol_types::{SolEvent, SolValue};
+use alloy::{primitives::B256, sol_types::SolValue};
 use eigen_task_processor::{
     task::Task, task_response::TaskResponse, task_response_metadata_sol::TaskResponseMetadataSol,
 };
@@ -9,17 +9,17 @@ use eigen_utils::slashing::middleware::iblssignaturechecker::BN254::G1Point;
 use crate::error::ChallengerError;
 
 pub trait ChallengerTaskProcessor {
-    /// Event type expected by the task processor
-    type NewTaskEvent: SolEvent;
-
-    /// Response type expected by the task processor
-    type TaskResponseEvent: SolEvent;
-
     /// Input type of the task
     type Input: Clone + SolValue + Send + Sync + 'static;
 
     /// Output type of the task
     type Output: Clone + SolValue + Send + Sync + 'static;
+
+    /// New task event
+    const NEW_TASK_EVENT_SELECTOR: B256;
+
+    /// Task responded event
+    const TASK_RESPONDED_EVENT_SELECTOR: B256;
 
     /// Handle the creation of a new task when a new task event is received
     ///

--- a/crates/challenger/src/challenger_processor.rs
+++ b/crates/challenger/src/challenger_processor.rs
@@ -1,5 +1,6 @@
 use crate::{challenger::ChallengerTaskProcessor, error::ChallengerError};
 use alloy::dyn_abi::SolType;
+use alloy::primitives::B256;
 use alloy::sol_types::SolValue;
 
 use eigen_task_processor::task_manager::TaskManagerContract;
@@ -27,13 +28,15 @@ where
     TM::Output: From<<<TM::Output as SolValue>::SolType as SolType>::RustType>,
     F: Fn(Task<TM::Input>, TaskResponse<TM::Output>) -> Result<bool, ChallengerError> + Send + Sync,
 {
-    type NewTaskEvent = TM::NewTaskEvent;
-
-    type TaskResponseEvent = TM::TaskRespondedEvent;
-
     type Input = TM::Input;
 
     type Output = TM::Output;
+
+    /// New task event
+    const NEW_TASK_EVENT_SELECTOR: B256 = TM::NEW_TASK_EVENT_SELECTOR;
+
+    /// Task responded event
+    const TASK_RESPONDED_EVENT_SELECTOR: B256 = TM::TASK_RESPONDED_EVENT_SELECTOR;
 
     async fn handle_task_creation(
         &mut self,

--- a/crates/challenger/src/lib.rs
+++ b/crates/challenger/src/lib.rs
@@ -5,7 +5,7 @@ use alloy::{
     primitives::Bytes,
     providers::Provider,
     rpc::types::{Filter, Log},
-    sol_types::{SolEvent, SolValue},
+    sol_types::SolValue,
 };
 use challenger::ChallengerTaskProcessor;
 use eigen_common::{get_provider, get_ws_provider};
@@ -96,14 +96,14 @@ where
         let ws_provider = get_ws_provider(&self.ws_url).await?;
 
         // Subscribe to NewTaskEvent
-        let task_filter = Filter::new().event_signature(TP::NewTaskEvent::SIGNATURE_HASH);
+        let task_filter = Filter::new().event_signature(TP::NEW_TASK_EVENT_SELECTOR);
         let mut task_stream = ws_provider
             .subscribe_logs(&task_filter)
             .await?
             .into_stream();
 
         // Subscribe to TaskResponseEvent
-        let responded_filter = Filter::new().event_signature(TP::TaskResponseEvent::SIGNATURE_HASH);
+        let responded_filter = Filter::new().event_signature(TP::TASK_RESPONDED_EVENT_SELECTOR);
         let mut responded_stream = ws_provider
             .subscribe_logs(&responded_filter)
             .await?

--- a/crates/task-processor/src/lib.rs
+++ b/crates/task-processor/src/lib.rs
@@ -83,11 +83,11 @@ impl<TM> TaskProcessor for IndexingTaskProcessor<TM>
 where
     TM: TaskManagerContract + Debug + Send + Sync + 'static + Clone,
 {
-    type NewTaskEvent = TM::NewTaskEvent;
-
     type Output = TM::Output;
 
     type Input = TM::Input;
+
+    const NEW_TASK_EVENT_SELECTOR: B256 = TM::NEW_TASK_EVENT_SELECTOR;
 
     async fn process_new_task(
         &mut self,

--- a/crates/task-processor/src/task_manager.rs
+++ b/crates/task-processor/src/task_manager.rs
@@ -3,7 +3,8 @@ use std::{fmt::Debug, future::Future};
 use crate::{
     task::Task, task_response::TaskResponse, task_response_metadata_sol::TaskResponseMetadataSol,
 };
-use alloy::sol_types::{SolEvent, SolValue};
+use alloy::primitives::B256;
+use alloy::sol_types::SolValue;
 use eigen_types::operator::{QuorumNum, QuorumThresholdPercentage};
 use eigen_utils::slashing::middleware::iblssignaturechecker::IBLSSignatureCheckerTypes::NonSignerStakesAndSignature;
 use eigen_utils::slashing::middleware::iblssignaturechecker::BN254::G1Point;
@@ -26,10 +27,10 @@ pub trait TaskManagerContract {
     type Output: Clone + SolValue + Send + Sync + 'static + Debug + DeserializeOwned;
 
     /// New task event
-    type NewTaskEvent: SolEvent;
+    const NEW_TASK_EVENT_SELECTOR: B256;
 
     /// Task responded event
-    type TaskRespondedEvent: SolEvent;
+    const TASK_RESPONDED_EVENT_SELECTOR: B256;
 
     /// Respond to a task
     ///

--- a/crates/task-processor/src/task_processor.rs
+++ b/crates/task-processor/src/task_processor.rs
@@ -1,4 +1,3 @@
-use alloy::sol_types::SolEvent;
 use alloy::{primitives::B256, sol_types::SolValue};
 use eigen_services_blsaggregation::{
     bls_agg::TaskMetadata, bls_aggregation_service_response::BlsAggregationServiceResponse,
@@ -12,14 +11,14 @@ use crate::task_response::TaskResponse;
 
 /// Abstracts task-specific behaviour
 pub trait TaskProcessor {
-    /// Event type expected by the task processor
-    type NewTaskEvent: SolEvent;
-
     /// Input type expected by the task processor
     type Input: SolValue + Send + Sync + 'static + Clone;
 
     /// Response type expected by the task processor
     type Output: SolValue + Send + Sync + 'static + Clone + DeserializeOwned;
+
+    /// Selector for the event signaling a new task
+    const NEW_TASK_EVENT_SELECTOR: B256;
 
     /// Creates the [`TaskMetadata`]
     ///

--- a/examples/incredible-squaring/src/lib.rs
+++ b/examples/incredible-squaring/src/lib.rs
@@ -3,7 +3,8 @@
 use alloy::{
     contract::private::{Provider, Transport},
     network::Network,
-    primitives::U256,
+    primitives::{B256, U256},
+    sol_types::SolEvent,
 };
 use bindings::incrediblesquaringtaskmanager::IIncredibleSquaringTaskManager::{
     Task as ContractTask, TaskResponse as ContractTaskResponse, TaskResponseMetadata,
@@ -48,8 +49,8 @@ where
 {
     type Input = U256;
     type Output = U256;
-    type NewTaskEvent = NewTaskCreated;
-    type TaskRespondedEvent = TaskResponded;
+    const NEW_TASK_EVENT_SELECTOR: B256 = NewTaskCreated::SIGNATURE_HASH;
+    const TASK_RESPONDED_EVENT_SELECTOR: B256 = TaskResponded::SIGNATURE_HASH;
 
     async fn create_new_task(
         &self,


### PR DESCRIPTION
### What Changed?

This PR simplifies the `TaskManagerContract` trait to only store the selector of the "new task" and "task responded" events.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
