### PR TITLE
feat(v2): add macro to implement `TaskManager` trait

### DIFF
--- a/crates/challenger/src/challenger_processor.rs
+++ b/crates/challenger/src/challenger_processor.rs
@@ -3,7 +3,7 @@ use alloy::dyn_abi::SolType;
 use alloy::primitives::B256;
 use alloy::sol_types::SolValue;
 
-use eigen_task_processor::task_manager::TaskManagerContract;
+use eigen_task_processor::task_manager::TaskManager;
 use eigen_task_processor::task_response_metadata_sol::TaskResponseMetadataSol;
 use eigen_task_processor::{task::Task, task_response::TaskResponse};
 use eigen_utils::slashing::middleware::iblssignaturechecker::BN254::G1Point;
@@ -13,7 +13,7 @@ use tracing::error;
 #[derive(Debug)]
 pub struct IndexingChallengerProcessor<TM, F>
 where
-    TM: TaskManagerContract + Send + Sync + 'static + Clone,
+    TM: TaskManager + Send + Sync + 'static + Clone,
     F: Fn(Task<TM::Input>, TaskResponse<TM::Output>) -> Result<bool, ChallengerError> + Send + Sync,
 {
     task_manager: TM,
@@ -23,7 +23,7 @@ where
 
 impl<TM, F> ChallengerTaskProcessor for IndexingChallengerProcessor<TM, F>
 where
-    TM: TaskManagerContract + Send + Sync + 'static + Clone,
+    TM: TaskManager + Send + Sync + 'static + Clone,
     TM::Input: From<<<TM::Input as SolValue>::SolType as SolType>::RustType>,
     TM::Output: From<<<TM::Output as SolValue>::SolType as SolType>::RustType>,
     F: Fn(Task<TM::Input>, TaskResponse<TM::Output>) -> Result<bool, ChallengerError> + Send + Sync,
@@ -78,7 +78,7 @@ where
 
 impl<TM, F> IndexingChallengerProcessor<TM, F>
 where
-    TM: TaskManagerContract + Send + Sync + 'static + Clone,
+    TM: TaskManager + Send + Sync + 'static + Clone,
     TM::Input: From<<<TM::Input as SolValue>::SolType as SolType>::RustType>,
     TM::Output: From<<<TM::Output as SolValue>::SolType as SolType>::RustType>,
     F: Fn(Task<TM::Input>, TaskResponse<TM::Output>) -> Result<bool, ChallengerError> + Send + Sync,

--- a/crates/task-processor/src/lib.rs
+++ b/crates/task-processor/src/lib.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{collections::HashMap, fmt::Debug};
 use task::Task;
-use task_manager::TaskManagerContract;
+use task_manager::TaskManager;
 use task_processor::TaskProcessor;
 use task_response::TaskResponse;
 use tokio::sync::Mutex;
@@ -41,7 +41,7 @@ type TaskResponsesMap<O> = HashMap<u32, HashMap<TaskResponseDigest, TaskResponse
 #[derive(Debug, Clone)]
 pub struct IndexingTaskProcessor<TM>
 where
-    TM: TaskManagerContract + Debug + Send + Sync + 'static + Clone,
+    TM: TaskManager + Debug + Send + Sync + 'static + Clone,
 {
     /// Hashmap to store the created tasks
     tasks: Arc<Mutex<HashMap<u32, Task<TM::Input>>>>,
@@ -57,7 +57,7 @@ where
 
 impl<TM> IndexingTaskProcessor<TM>
 where
-    TM: TaskManagerContract + Debug + Send + Sync + 'static + Clone,
+    TM: TaskManager + Debug + Send + Sync + 'static + Clone,
 {
     /// Create a new task processor
     ///
@@ -81,7 +81,7 @@ where
 
 impl<TM> TaskProcessor for IndexingTaskProcessor<TM>
 where
-    TM: TaskManagerContract + Debug + Send + Sync + 'static + Clone,
+    TM: TaskManager + Debug + Send + Sync + 'static + Clone,
 {
     type Output = TM::Output;
 

--- a/crates/task-processor/src/task_manager.rs
+++ b/crates/task-processor/src/task_manager.rs
@@ -88,3 +88,136 @@ pub trait TaskManagerContract {
         pubkeys_of_non_signing_operators: Vec<G1Point>,
     ) -> impl Future<Output = Result<(), TaskManagerError>> + Send;
 }
+
+#[macro_export]
+/// This macro generates a default implementation of the `TaskManagerContract` trait's methods.
+macro_rules! default_contract_impl {
+    () => {
+        async fn create_new_task(
+            &self,
+            input: Self::Input,
+            quorum_threshold: QuorumThresholdPercentage,
+            quorums: Vec<QuorumNum>,
+        ) -> Result<(), TaskManagerError> {
+            self.createNewTask(input, quorum_threshold.into(), quorums.into())
+                .send()
+                .await
+                .map_err(box_error)?
+                .get_receipt()
+                .await
+                .map_err(box_error)
+                .map(|_| ())
+        }
+
+        async fn respond_to_task(
+            &self,
+            task: Task<Self::Input>,
+            task_response: TaskResponse<Self::Output>,
+            non_signer_stakes_and_signature: NonSignerStakesAndSignature,
+        ) -> Result<(), TaskManagerError> {
+            let contract_task = (
+                task.input,
+                task.task_created_block,
+                task.quorum_numbers,
+                task.quorum_threshold_percentage,
+            )
+                .into();
+
+            let contract_response = (task_response.task_index, task_response.response).into();
+
+            let apk_g2 = (
+                non_signer_stakes_and_signature.apkG2.X,
+                non_signer_stakes_and_signature.apkG2.Y,
+            )
+                .into();
+
+            let sigma = (
+                non_signer_stakes_and_signature.sigma.X,
+                non_signer_stakes_and_signature.sigma.Y,
+            )
+                .into();
+
+            let quorum_apks = non_signer_stakes_and_signature
+                .quorumApks
+                .iter()
+                .map(|apk| (apk.X, apk.Y).into())
+                .collect();
+
+            let non_signer_pubkeys = non_signer_stakes_and_signature
+                .nonSignerPubkeys
+                .iter()
+                .map(|pubkey| (pubkey.X, pubkey.Y).into())
+                .collect();
+
+            let non_signer_stakes_and_signature = (
+                non_signer_stakes_and_signature.nonSignerQuorumBitmapIndices,
+                non_signer_pubkeys,
+                quorum_apks,
+                apk_g2,
+                sigma,
+                non_signer_stakes_and_signature.quorumApkIndices,
+                non_signer_stakes_and_signature.totalStakeIndices,
+                non_signer_stakes_and_signature.nonSignerStakeIndices,
+            )
+                .into();
+
+            self.respondToTask(
+                contract_task,
+                contract_response,
+                non_signer_stakes_and_signature,
+            )
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+
+            Ok(())
+        }
+
+        async fn raise_challenge(
+            &self,
+            task: Task<Self::Input>,
+            task_response: TaskResponse<Self::Output>,
+            task_response_metadata: TaskResponseMetadataSol,
+            pubkeys_of_non_signing_operators: Vec<G1Point>,
+        ) -> Result<(), TaskManagerError> {
+            let contract_task = (
+                task.input,
+                task.task_created_block,
+                task.quorum_numbers,
+                task.quorum_threshold_percentage,
+            )
+                .into();
+
+            let contract_response = (task_response.task_index, task_response.response).into();
+
+            let task_response_metadata = (
+                task_response_metadata.taskResponsedBlock,
+                task_response_metadata.hashOfNonSigners,
+            )
+                .into();
+
+            let pubkey_non_signer = pubkeys_of_non_signing_operators
+                .iter()
+                .map(|p| (p.X, p.Y).into())
+                .collect();
+
+            self.raiseAndResolveChallenge(
+                contract_task,
+                contract_response,
+                task_response_metadata,
+                pubkey_non_signer,
+            )
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+
+            Ok(())
+        }
+    };
+}

--- a/crates/task-processor/src/task_manager.rs
+++ b/crates/task-processor/src/task_manager.rs
@@ -20,7 +20,7 @@ pub fn box_error<E: core::error::Error + Send + 'static>(e: E) -> TaskManagerErr
 }
 
 /// Task manager contract trait. It wraps the contract's types and functions.
-pub trait TaskManagerContract {
+pub trait TaskManager {
     /// Type for inputs of each task
     type Input: Clone + SolValue + Send + Sync + 'static + Debug;
 
@@ -91,7 +91,7 @@ pub trait TaskManagerContract {
 }
 
 #[macro_export]
-/// Implements the [`TaskManagerContract`] trait for the given contract.
+/// Implements the [`TaskManager`] trait for the given contract.
 /// This requires the contract to have [`createNewTask`], [`respondToTask`] and [`raiseAndResolveChallenge`] functions.
 macro_rules! impl_task_manager {
     (Contract = $contract:ident,
@@ -99,7 +99,7 @@ macro_rules! impl_task_manager {
         Output = $output:ty,
         NewTaskEvent = $new_task_event:ty,
         TaskRespondedEvent = $task_responded_event:ty $(,)*) => {
-        impl<T, P, N> $crate::task_manager::TaskManagerContract for $contract<T, P, N>
+        impl<T, P, N> $crate::task_manager::TaskManager for $contract<T, P, N>
         where
             T: ::alloy::contract::private::Transport + Clone + Send + Sync,
             P: ::alloy::contract::private::Provider<T, N>,
@@ -118,7 +118,7 @@ macro_rules! impl_task_manager {
 }
 
 #[macro_export]
-/// This macro generates a default implementation of the [`TaskManagerContract`] trait's methods.
+/// This macro generates a default implementation of the [`TaskManager`] trait's methods.
 /// /// This requires the contract to have [`createNewTask`], [`respondToTask`] and [`raiseAndResolveChallenge`] functions.
 macro_rules! default_contract_impl {
     () => {

--- a/crates/task-processor/src/task_manager.rs
+++ b/crates/task-processor/src/task_manager.rs
@@ -119,7 +119,7 @@ macro_rules! impl_task_manager {
 
 #[macro_export]
 /// This macro generates a default implementation of the [`TaskManager`] trait's methods.
-/// /// This requires the contract to have [`createNewTask`], [`respondToTask`] and [`raiseAndResolveChallenge`] functions.
+/// This requires the contract to have [`createNewTask`], [`respondToTask`] and [`raiseAndResolveChallenge`] functions.
 macro_rules! default_contract_impl {
     () => {
         async fn create_new_task(

--- a/crates/task-processor/src/task_manager.rs
+++ b/crates/task-processor/src/task_manager.rs
@@ -134,8 +134,9 @@ macro_rules! default_contract_impl {
                 .map_err($crate::task_manager::box_error)?
                 .get_receipt()
                 .await
-                .map_err($crate::task_manager::box_error)
-                .map(|_| ())
+                .map_err($crate::task_manager::box_error)?;
+
+            Ok(())
         }
 
         async fn respond_to_task(
@@ -197,10 +198,10 @@ macro_rules! default_contract_impl {
             )
             .send()
             .await
-            .unwrap()
+            .map_err($crate::task_manager::box_error)?
             .get_receipt()
             .await
-            .unwrap();
+            .map_err($crate::task_manager::box_error)?;
 
             Ok(())
         }
@@ -241,10 +242,10 @@ macro_rules! default_contract_impl {
             )
             .send()
             .await
-            .unwrap()
+            .map_err($crate::task_manager::box_error)?
             .get_receipt()
             .await
-            .unwrap();
+            .map_err($crate::task_manager::box_error)?;
 
             Ok(())
         }

--- a/crates/task-processor/src/task_manager.rs
+++ b/crates/task-processor/src/task_manager.rs
@@ -112,7 +112,7 @@ macro_rules! impl_task_manager {
             const TASK_RESPONDED_EVENT_SELECTOR: ::alloy::primitives::B256 =
                 <$task_responded_event as ::alloy::sol_types::SolEvent>::SIGNATURE_HASH;
 
-            default_contract_impl! {}
+            $crate::default_contract_impl! {}
         }
     };
 }

--- a/crates/task-processor/src/task_manager.rs
+++ b/crates/task-processor/src/task_manager.rs
@@ -5,10 +5,11 @@ use crate::{
 };
 use alloy::primitives::B256;
 use alloy::sol_types::SolValue;
-use eigen_types::operator::{QuorumNum, QuorumThresholdPercentage};
-use eigen_utils::slashing::middleware::iblssignaturechecker::IBLSSignatureCheckerTypes::NonSignerStakesAndSignature;
-use eigen_utils::slashing::middleware::iblssignaturechecker::BN254::G1Point;
 use serde::de::DeserializeOwned;
+
+pub use eigen_types::operator::{QuorumNum, QuorumThresholdPercentage};
+pub use eigen_utils::slashing::middleware::iblssignaturechecker::IBLSSignatureCheckerTypes::NonSignerStakesAndSignature;
+pub use eigen_utils::slashing::middleware::iblssignaturechecker::BN254::G1Point;
 
 /// Error returned by the task processor
 pub type TaskManagerError = Box<dyn core::error::Error + Send>;
@@ -90,31 +91,59 @@ pub trait TaskManagerContract {
 }
 
 #[macro_export]
-/// This macro generates a default implementation of the `TaskManagerContract` trait's methods.
+/// Implements the [`TaskManagerContract`] trait for the given contract.
+/// This requires the contract to have [`createNewTask`], [`respondToTask`] and [`raiseAndResolveChallenge`] functions.
+macro_rules! impl_task_manager {
+    (Contract = $contract:ident,
+        Input = $input:ty,
+        Output = $output:ty,
+        NewTaskEvent = $new_task_event:ty,
+        TaskRespondedEvent = $task_responded_event:ty $(,)*) => {
+        impl<T, P, N> $crate::task_manager::TaskManagerContract for $contract<T, P, N>
+        where
+            T: ::alloy::contract::private::Transport + Clone + Send + Sync,
+            P: ::alloy::contract::private::Provider<T, N>,
+            N: ::alloy::network::Network,
+        {
+            type Input = $input;
+            type Output = $output;
+            const NEW_TASK_EVENT_SELECTOR: ::alloy::primitives::B256 =
+                <$new_task_event as ::alloy::sol_types::SolEvent>::SIGNATURE_HASH;
+            const TASK_RESPONDED_EVENT_SELECTOR: ::alloy::primitives::B256 =
+                <$task_responded_event as ::alloy::sol_types::SolEvent>::SIGNATURE_HASH;
+
+            default_contract_impl! {}
+        }
+    };
+}
+
+#[macro_export]
+/// This macro generates a default implementation of the [`TaskManagerContract`] trait's methods.
+/// /// This requires the contract to have [`createNewTask`], [`respondToTask`] and [`raiseAndResolveChallenge`] functions.
 macro_rules! default_contract_impl {
     () => {
         async fn create_new_task(
             &self,
             input: Self::Input,
-            quorum_threshold: QuorumThresholdPercentage,
-            quorums: Vec<QuorumNum>,
-        ) -> Result<(), TaskManagerError> {
+            quorum_threshold: $crate::task_manager::QuorumThresholdPercentage,
+            quorums: Vec<$crate::task_manager::QuorumNum>,
+        ) -> Result<(), $crate::task_manager::TaskManagerError> {
             self.createNewTask(input, quorum_threshold.into(), quorums.into())
                 .send()
                 .await
-                .map_err(box_error)?
+                .map_err($crate::task_manager::box_error)?
                 .get_receipt()
                 .await
-                .map_err(box_error)
+                .map_err($crate::task_manager::box_error)
                 .map(|_| ())
         }
 
         async fn respond_to_task(
             &self,
-            task: Task<Self::Input>,
-            task_response: TaskResponse<Self::Output>,
-            non_signer_stakes_and_signature: NonSignerStakesAndSignature,
-        ) -> Result<(), TaskManagerError> {
+            task: $crate::task::Task<Self::Input>,
+            task_response: $crate::task_response::TaskResponse<Self::Output>,
+            non_signer_stakes_and_signature: $crate::task_manager::NonSignerStakesAndSignature,
+        ) -> Result<(), $crate::task_manager::TaskManagerError> {
             let contract_task = (
                 task.input,
                 task.task_created_block,
@@ -178,11 +207,11 @@ macro_rules! default_contract_impl {
 
         async fn raise_challenge(
             &self,
-            task: Task<Self::Input>,
-            task_response: TaskResponse<Self::Output>,
-            task_response_metadata: TaskResponseMetadataSol,
-            pubkeys_of_non_signing_operators: Vec<G1Point>,
-        ) -> Result<(), TaskManagerError> {
+            task: $crate::task::Task<Self::Input>,
+            task_response: $crate::task_response::TaskResponse<Self::Output>,
+            task_response_metadata: $crate::task_response_metadata_sol::TaskResponseMetadataSol,
+            pubkeys_of_non_signing_operators: Vec<$crate::task_manager::G1Point>,
+        ) -> Result<(), $crate::task_manager::TaskManagerError> {
             let contract_task = (
                 task.input,
                 task.task_created_block,

--- a/crates/task-spammer/src/lib.rs
+++ b/crates/task-spammer/src/lib.rs
@@ -1,7 +1,7 @@
 //! This is a simple task generator that can be used to create tasks for the operators.
 //! For testing purposes.
 
-use eigen_task_processor::task_manager::TaskManagerContract;
+use eigen_task_processor::task_manager::TaskManager;
 use eigen_types::operator::{QuorumNum, QuorumThresholdPercentage};
 use error::TaskSpammerError;
 use std::time::Duration;
@@ -22,7 +22,7 @@ pub struct TaskSpammerBuilder<I, TM> {
 
 impl<I, TM> TaskSpammerBuilder<I, TM>
 where
-    TM: TaskManagerContract,
+    TM: TaskManager,
 {
     /// Create a new task spammer builder
     ///
@@ -132,7 +132,7 @@ pub struct TaskSpammer<I, TM> {
 
 impl<I, TM> TaskSpammer<I, TM>
 where
-    TM: TaskManagerContract + Send + Sync,
+    TM: TaskManager + Send + Sync,
 {
     /// Run the task spammer
     /// This will create N tasks, where N is the number of items in the iterator

--- a/examples/incredible-squaring/src/lib.rs
+++ b/examples/incredible-squaring/src/lib.rs
@@ -4,7 +4,7 @@ use alloy::primitives::U256;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::IncredibleSquaringTaskManagerInstance;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::NewTaskCreated;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::TaskResponded;
-use eigen_task_processor::{default_contract_impl, impl_task_manager};
+use eigen_task_processor::impl_task_manager;
 
 // Allow warnings in auto-generated code
 #[allow(warnings)]

--- a/examples/incredible-squaring/src/lib.rs
+++ b/examples/incredible-squaring/src/lib.rs
@@ -10,6 +10,7 @@ use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::Incr
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::NewTaskCreated;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::TaskResponded;
 use eigen_task_processor::{
+    default_contract_impl,
     task::Task,
     task_manager::{box_error, TaskManagerContract, TaskManagerError},
     task_response::TaskResponse,
@@ -45,130 +46,5 @@ where
     const NEW_TASK_EVENT_SELECTOR: B256 = NewTaskCreated::SIGNATURE_HASH;
     const TASK_RESPONDED_EVENT_SELECTOR: B256 = TaskResponded::SIGNATURE_HASH;
 
-    async fn create_new_task(
-        &self,
-        input: U256,
-        quorum_threshold: QuorumThresholdPercentage,
-        quorums: Vec<QuorumNum>,
-    ) -> Result<(), TaskManagerError> {
-        self.createNewTask(input, quorum_threshold.into(), quorums.into())
-            .send()
-            .await
-            .map_err(box_error)?
-            .get_receipt()
-            .await
-            .map_err(box_error)
-            .map(|_| ())
-    }
-
-    async fn respond_to_task(
-        &self,
-        task: Task<Self::Input>,
-        task_response: TaskResponse<Self::Output>,
-        non_signer_stakes_and_signature: NonSignerStakesAndSignature,
-    ) -> Result<(), TaskManagerError> {
-        let contract_task = (
-            task.input,
-            task.task_created_block,
-            task.quorum_numbers,
-            task.quorum_threshold_percentage,
-        )
-            .into();
-
-        let contract_response = (task_response.task_index, task_response.response).into();
-
-        let apk_g2 = (
-            non_signer_stakes_and_signature.apkG2.X,
-            non_signer_stakes_and_signature.apkG2.Y,
-        )
-            .into();
-
-        let sigma = (
-            non_signer_stakes_and_signature.sigma.X,
-            non_signer_stakes_and_signature.sigma.Y,
-        )
-            .into();
-
-        let quorum_apks = non_signer_stakes_and_signature
-            .quorumApks
-            .iter()
-            .map(|apk| (apk.X, apk.Y).into())
-            .collect();
-
-        let non_signer_pubkeys = non_signer_stakes_and_signature
-            .nonSignerPubkeys
-            .iter()
-            .map(|pubkey| (pubkey.X, pubkey.Y).into())
-            .collect();
-
-        let non_signer_stakes_and_signature = (
-            non_signer_stakes_and_signature.nonSignerQuorumBitmapIndices,
-            non_signer_pubkeys,
-            quorum_apks,
-            apk_g2,
-            sigma,
-            non_signer_stakes_and_signature.quorumApkIndices,
-            non_signer_stakes_and_signature.totalStakeIndices,
-            non_signer_stakes_and_signature.nonSignerStakeIndices,
-        )
-            .into();
-
-        self.respondToTask(
-            contract_task,
-            contract_response,
-            non_signer_stakes_and_signature,
-        )
-        .send()
-        .await
-        .unwrap()
-        .get_receipt()
-        .await
-        .unwrap();
-
-        Ok(())
-    }
-
-    async fn raise_challenge(
-        &self,
-        task: Task<Self::Input>,
-        task_response: TaskResponse<Self::Output>,
-        task_response_metadata: TaskResponseMetadataSol,
-        pubkeys_of_non_signing_operators: Vec<G1Point>,
-    ) -> Result<(), TaskManagerError> {
-        let contract_task = (
-            task.input,
-            task.task_created_block,
-            task.quorum_numbers,
-            task.quorum_threshold_percentage,
-        )
-            .into();
-
-        let contract_response = (task_response.task_index, task_response.response).into();
-
-        let task_response_metadata = (
-            task_response_metadata.taskResponsedBlock,
-            task_response_metadata.hashOfNonSigners,
-        )
-            .into();
-
-        let pubkey_non_signer = pubkeys_of_non_signing_operators
-            .iter()
-            .map(|p| (p.X, p.Y).into())
-            .collect();
-
-        self.raiseAndResolveChallenge(
-            contract_task,
-            contract_response,
-            task_response_metadata,
-            pubkey_non_signer,
-        )
-        .send()
-        .await
-        .unwrap()
-        .get_receipt()
-        .await
-        .unwrap();
-
-        Ok(())
-    }
+    default_contract_impl! {}
 }

--- a/examples/incredible-squaring/src/lib.rs
+++ b/examples/incredible-squaring/src/lib.rs
@@ -1,24 +1,10 @@
 //! Example AVS which squares a number
 
-use alloy::{
-    contract::private::{Provider, Transport},
-    network::Network,
-    primitives::{B256, U256},
-    sol_types::SolEvent,
-};
+use alloy::primitives::U256;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::IncredibleSquaringTaskManagerInstance;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::NewTaskCreated;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::TaskResponded;
-use eigen_task_processor::{
-    default_contract_impl,
-    task::Task,
-    task_manager::{box_error, TaskManagerContract, TaskManagerError},
-    task_response::TaskResponse,
-    task_response_metadata_sol::TaskResponseMetadataSol,
-};
-use eigen_types::operator::{QuorumNum, QuorumThresholdPercentage};
-use eigen_utils::slashing::middleware::iblssignaturechecker::IBLSSignatureCheckerTypes::NonSignerStakesAndSignature;
-use eigen_utils::slashing::middleware::iblssignaturechecker::BN254::G1Point;
+use eigen_task_processor::{default_contract_impl, impl_task_manager};
 
 // Allow warnings in auto-generated code
 #[allow(warnings)]
@@ -35,16 +21,10 @@ pub mod bindings;
 // struct TaskManagerWrapper<T, P, N>(IncredibleSquaringTaskManagerInstance<T, P, N>);
 //
 // impl<T, P, N> TaskManagerContract<U256, T, P, N> for TaskManagerWrapper<T, P, N> { ... }
-impl<T, P, N> TaskManagerContract for IncredibleSquaringTaskManagerInstance<T, P, N>
-where
-    T: Transport + Clone + Send + Sync,
-    P: Provider<T, N>,
-    N: Network,
-{
-    type Input = U256;
-    type Output = U256;
-    const NEW_TASK_EVENT_SELECTOR: B256 = NewTaskCreated::SIGNATURE_HASH;
-    const TASK_RESPONDED_EVENT_SELECTOR: B256 = TaskResponded::SIGNATURE_HASH;
-
-    default_contract_impl! {}
-}
+impl_task_manager!(
+    Contract = IncredibleSquaringTaskManagerInstance,
+    Input = U256,
+    Output = U256,
+    NewTaskEvent = NewTaskCreated,
+    TaskRespondedEvent = TaskResponded,
+);

--- a/examples/incredible-squaring/src/lib.rs
+++ b/examples/incredible-squaring/src/lib.rs
@@ -10,17 +10,17 @@ use eigen_task_processor::{default_contract_impl, impl_task_manager};
 #[allow(warnings)]
 pub mod bindings;
 
-// Implement the TaskManagerContract trait for the task manager contract.
+// Implement the TaskManager trait for the task manager contract.
 // You need to specify the input type of the task. In this case, U256.
 // You also need to specify the call type of the task manager contract. `createNewTask` uses `createNewTaskCall`.
 // You also need to specify the provider and network types.
 //
-// NOTE: When you are implementing this, you will have an exteranl trait `TaskManagerContract` and and external struct
+// NOTE: When you are implementing this, you will have an external trait `TaskManager` and an external struct
 // `CONTRACT_NAME_INSTANCE`, so it will throw an error. You can wrap the external struct in a newtype to avoid this.
 // Example:
 // struct TaskManagerWrapper<T, P, N>(IncredibleSquaringTaskManagerInstance<T, P, N>);
 //
-// impl<T, P, N> TaskManagerContract<U256, T, P, N> for TaskManagerWrapper<T, P, N> { ... }
+// impl<T, P, N> TaskManager<U256, T, P, N> for TaskManagerWrapper<T, P, N> { ... }
 impl_task_manager!(
     Contract = IncredibleSquaringTaskManagerInstance,
     Input = U256,

--- a/examples/incredible-squaring/src/lib.rs
+++ b/examples/incredible-squaring/src/lib.rs
@@ -6,16 +6,9 @@ use alloy::{
     primitives::{B256, U256},
     sol_types::SolEvent,
 };
-use bindings::incrediblesquaringtaskmanager::IIncredibleSquaringTaskManager::{
-    Task as ContractTask, TaskResponse as ContractTaskResponse, TaskResponseMetadata,
-};
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::IncredibleSquaringTaskManagerInstance;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::NewTaskCreated;
-use bindings::incrediblesquaringtaskmanager::BN254::{G1Point as G1Binding, G2Point};
-use bindings::incrediblesquaringtaskmanager::{
-    IBLSSignatureCheckerTypes::NonSignerStakesAndSignature as ContractNonSignerStakesAndSignature,
-    IncredibleSquaringTaskManager::TaskResponded,
-};
+use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::TaskResponded;
 use eigen_task_processor::{
     task::Task,
     task_manager::{box_error, TaskManagerContract, TaskManagerError},
@@ -71,57 +64,54 @@ where
     async fn respond_to_task(
         &self,
         task: Task<Self::Input>,
-        response: TaskResponse<Self::Output>,
+        task_response: TaskResponse<Self::Output>,
         non_signer_stakes_and_signature: NonSignerStakesAndSignature,
     ) -> Result<(), TaskManagerError> {
-        let contract_task = ContractTask {
-            numberToBeSquared: task.input,
-            taskCreatedBlock: task.task_created_block,
-            quorumNumbers: task.quorum_numbers,
-            quorumThresholdPercentage: task.quorum_threshold_percentage,
-        };
+        let contract_task = (
+            task.input,
+            task.task_created_block,
+            task.quorum_numbers,
+            task.quorum_threshold_percentage,
+        )
+            .into();
 
-        let contract_response = ContractTaskResponse {
-            numberSquared: response.response,
-            referenceTaskIndex: response.task_index,
-        };
+        let contract_response = (task_response.task_index, task_response.response).into();
 
-        let apk_g2 = G2Point {
-            X: non_signer_stakes_and_signature.apkG2.X,
-            Y: non_signer_stakes_and_signature.apkG2.Y,
-        };
+        let apk_g2 = (
+            non_signer_stakes_and_signature.apkG2.X,
+            non_signer_stakes_and_signature.apkG2.Y,
+        )
+            .into();
 
-        let sigma = G1Binding {
-            X: non_signer_stakes_and_signature.sigma.X,
-            Y: non_signer_stakes_and_signature.sigma.Y,
-        };
+        let sigma = (
+            non_signer_stakes_and_signature.sigma.X,
+            non_signer_stakes_and_signature.sigma.Y,
+        )
+            .into();
 
         let quorum_apks = non_signer_stakes_and_signature
             .quorumApks
             .iter()
-            .map(|apk| G1Binding { X: apk.X, Y: apk.Y })
+            .map(|apk| (apk.X, apk.Y).into())
             .collect();
 
         let non_signer_pubkeys = non_signer_stakes_and_signature
             .nonSignerPubkeys
             .iter()
-            .map(|pubkey| G1Binding {
-                X: pubkey.X,
-                Y: pubkey.Y,
-            })
+            .map(|pubkey| (pubkey.X, pubkey.Y).into())
             .collect();
 
-        let non_signer_stakes_and_signature = ContractNonSignerStakesAndSignature {
-            nonSignerStakeIndices: non_signer_stakes_and_signature.nonSignerStakeIndices,
-            nonSignerQuorumBitmapIndices: non_signer_stakes_and_signature
-                .nonSignerQuorumBitmapIndices,
-            quorumApkIndices: non_signer_stakes_and_signature.quorumApkIndices,
-            totalStakeIndices: non_signer_stakes_and_signature.totalStakeIndices,
-            apkG2: apk_g2,
-            quorumApks: quorum_apks,
-            nonSignerPubkeys: non_signer_pubkeys,
+        let non_signer_stakes_and_signature = (
+            non_signer_stakes_and_signature.nonSignerQuorumBitmapIndices,
+            non_signer_pubkeys,
+            quorum_apks,
+            apk_g2,
             sigma,
-        };
+            non_signer_stakes_and_signature.quorumApkIndices,
+            non_signer_stakes_and_signature.totalStakeIndices,
+            non_signer_stakes_and_signature.nonSignerStakeIndices,
+        )
+            .into();
 
         self.respondToTask(
             contract_task,
@@ -145,26 +135,25 @@ where
         task_response_metadata: TaskResponseMetadataSol,
         pubkeys_of_non_signing_operators: Vec<G1Point>,
     ) -> Result<(), TaskManagerError> {
-        let contract_task = ContractTask {
-            numberToBeSquared: task.input,
-            taskCreatedBlock: task.task_created_block,
-            quorumNumbers: task.quorum_numbers,
-            quorumThresholdPercentage: task.quorum_threshold_percentage,
-        };
+        let contract_task = (
+            task.input,
+            task.task_created_block,
+            task.quorum_numbers,
+            task.quorum_threshold_percentage,
+        )
+            .into();
 
-        let contract_response = ContractTaskResponse {
-            numberSquared: task_response.response,
-            referenceTaskIndex: task_response.task_index,
-        };
+        let contract_response = (task_response.task_index, task_response.response).into();
 
-        let task_response_metadata = TaskResponseMetadata {
-            taskResponsedBlock: task_response_metadata.taskResponsedBlock,
-            hashOfNonSigners: task_response_metadata.hashOfNonSigners,
-        };
+        let task_response_metadata = (
+            task_response_metadata.taskResponsedBlock,
+            task_response_metadata.hashOfNonSigners,
+        )
+            .into();
 
         let pubkey_non_signer = pubkeys_of_non_signing_operators
             .iter()
-            .map(|p| G1Binding { X: p.X, Y: p.Y })
+            .map(|p| (p.X, p.Y).into())
             .collect();
 
         self.raiseAndResolveChallenge(


### PR DESCRIPTION
### What Changed?

This PR adds a macro to implement the `TaskManagerContract` trait. It also renames the trait to `TaskManager`.

The change reduces the example's code by ~150 lines.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
