### PR TITLE
feat(v2): split `TaskManager` trait and simplify macros

### DIFF
--- a/crates/task-processor/src/task_manager.rs
+++ b/crates/task-processor/src/task_manager.rs
@@ -19,6 +19,8 @@ pub fn box_error<E: core::error::Error + Send + 'static>(e: E) -> TaskManagerErr
     Box::new(e)
 }
 
+/// Task manager contract definitions.
+/// Defines the types and constants used in [`TaskManager`] and across the SDK.
 pub trait TaskManagerDefs {
     /// Type for inputs of each task
     type Input: Clone + SolValue + Send + Sync + 'static + Debug;
@@ -92,38 +94,23 @@ pub trait TaskManager: TaskManagerDefs {
     ) -> impl Future<Output = Result<(), TaskManagerError>> + Send;
 }
 
-// #[macro_export]
-// /// Implements the [`TaskManager`] trait for the given contract.
-// /// This requires the contract to have [`createNewTask`], [`respondToTask`] and [`raiseAndResolveChallenge`] functions.
-// macro_rules! impl_task_manager_from_defs_and_contract {
-//     (Contract = $contract:ident,
-//         Input = $input:ty,
-//         Output = $output:ty,
-//         NewTaskEvent = $new_task_event:ty,
-//         TaskRespondedEvent = $task_responded_event:ty $(,)*) => {};
-// }
-
 #[macro_export]
 /// Implements the [`TaskManager`] trait for the given contract.
 /// This requires the contract to have [`createNewTask`], [`respondToTask`] and [`raiseAndResolveChallenge`] functions.
-macro_rules! impl_task_manager {
-    (Contract = $contract:ident,
-        Input = $input:ty,
-        Output = $output:ty,
-        NewTaskEvent = $new_task_event:ty,
-        TaskRespondedEvent = $task_responded_event:ty $(,)*) => {
+macro_rules! impl_task_manager_from_defs_and_contract {
+    ($defs:ty => $contract:ident) => {
         impl<T, P, N> $crate::task_manager::TaskManagerDefs for $contract<T, P, N>
         where
             T: ::alloy::contract::private::Transport + Clone + Send + Sync,
             P: ::alloy::contract::private::Provider<T, N>,
             N: ::alloy::network::Network,
         {
-            type Input = $input;
-            type Output = $output;
+            type Input = <$defs as $crate::task_manager::TaskManagerDefs>::Input;
+            type Output = <$defs as $crate::task_manager::TaskManagerDefs>::Output;
             const NEW_TASK_EVENT_SELECTOR: ::alloy::primitives::B256 =
-                <$new_task_event as ::alloy::sol_types::SolEvent>::SIGNATURE_HASH;
+                <$defs as $crate::task_manager::TaskManagerDefs>::NEW_TASK_EVENT_SELECTOR;
             const TASK_RESPONDED_EVENT_SELECTOR: ::alloy::primitives::B256 =
-                <$task_responded_event as ::alloy::sol_types::SolEvent>::SIGNATURE_HASH;
+                <$defs as $crate::task_manager::TaskManagerDefs>::TASK_RESPONDED_EVENT_SELECTOR;
         }
 
         impl<T, P, N> $crate::task_manager::TaskManager for $contract<T, P, N>
@@ -132,7 +119,7 @@ macro_rules! impl_task_manager {
             P: ::alloy::contract::private::Provider<T, N>,
             N: ::alloy::network::Network,
         {
-            $crate::default_contract_impl! {}
+            $crate::default_contract_impl!();
         }
     };
 }

--- a/crates/task-processor/src/task_manager.rs
+++ b/crates/task-processor/src/task_manager.rs
@@ -19,8 +19,7 @@ pub fn box_error<E: core::error::Error + Send + 'static>(e: E) -> TaskManagerErr
     Box::new(e)
 }
 
-/// Task manager contract trait. It wraps the contract's types and functions.
-pub trait TaskManager {
+pub trait TaskManagerDefs {
     /// Type for inputs of each task
     type Input: Clone + SolValue + Send + Sync + 'static + Debug;
 
@@ -32,7 +31,10 @@ pub trait TaskManager {
 
     /// Task responded event
     const TASK_RESPONDED_EVENT_SELECTOR: B256;
+}
 
+/// Task manager contract trait. It wraps the contract's types and functions.
+pub trait TaskManager: TaskManagerDefs {
     /// Respond to a task
     ///
     /// # Arguments
@@ -90,6 +92,17 @@ pub trait TaskManager {
     ) -> impl Future<Output = Result<(), TaskManagerError>> + Send;
 }
 
+// #[macro_export]
+// /// Implements the [`TaskManager`] trait for the given contract.
+// /// This requires the contract to have [`createNewTask`], [`respondToTask`] and [`raiseAndResolveChallenge`] functions.
+// macro_rules! impl_task_manager_from_defs_and_contract {
+//     (Contract = $contract:ident,
+//         Input = $input:ty,
+//         Output = $output:ty,
+//         NewTaskEvent = $new_task_event:ty,
+//         TaskRespondedEvent = $task_responded_event:ty $(,)*) => {};
+// }
+
 #[macro_export]
 /// Implements the [`TaskManager`] trait for the given contract.
 /// This requires the contract to have [`createNewTask`], [`respondToTask`] and [`raiseAndResolveChallenge`] functions.
@@ -99,7 +112,7 @@ macro_rules! impl_task_manager {
         Output = $output:ty,
         NewTaskEvent = $new_task_event:ty,
         TaskRespondedEvent = $task_responded_event:ty $(,)*) => {
-        impl<T, P, N> $crate::task_manager::TaskManager for $contract<T, P, N>
+        impl<T, P, N> $crate::task_manager::TaskManagerDefs for $contract<T, P, N>
         where
             T: ::alloy::contract::private::Transport + Clone + Send + Sync,
             P: ::alloy::contract::private::Provider<T, N>,
@@ -111,7 +124,14 @@ macro_rules! impl_task_manager {
                 <$new_task_event as ::alloy::sol_types::SolEvent>::SIGNATURE_HASH;
             const TASK_RESPONDED_EVENT_SELECTOR: ::alloy::primitives::B256 =
                 <$task_responded_event as ::alloy::sol_types::SolEvent>::SIGNATURE_HASH;
+        }
 
+        impl<T, P, N> $crate::task_manager::TaskManager for $contract<T, P, N>
+        where
+            T: ::alloy::contract::private::Transport + Clone + Send + Sync,
+            P: ::alloy::contract::private::Provider<T, N>,
+            N: ::alloy::network::Network,
+        {
             $crate::default_contract_impl! {}
         }
     };

--- a/examples/incredible-squaring/src/lib.rs
+++ b/examples/incredible-squaring/src/lib.rs
@@ -6,32 +6,16 @@ use alloy::sol_types::SolEvent;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::IncredibleSquaringTaskManagerInstance;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::NewTaskCreated;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::TaskResponded;
-use eigen_task_processor::impl_task_manager;
+use eigen_task_processor::impl_task_manager_from_defs_and_contract;
 use eigen_task_processor::task_manager::TaskManagerDefs;
 
 // Allow warnings in auto-generated code
 #[allow(warnings)]
 pub mod bindings;
 
-// Implement the TaskManager trait for the task manager contract.
-// You need to specify the input type of the task. In this case, U256.
-// You also need to specify the call type of the task manager contract. `createNewTask` uses `createNewTaskCall`.
-// You also need to specify the provider and network types.
-//
-// NOTE: When you are implementing this, you will have an external trait `TaskManager` and an external struct
-// `CONTRACT_NAME_INSTANCE`, so it will throw an error. You can wrap the external struct in a newtype to avoid this.
-// Example:
-// struct TaskManagerWrapper<T, P, N>(IncredibleSquaringTaskManagerInstance<T, P, N>);
-//
-// impl<T, P, N> TaskManager<U256, T, P, N> for TaskManagerWrapper<T, P, N> { ... }
-impl_task_manager!(
-    Contract = IncredibleSquaringTaskManagerInstance,
-    Input = U256,
-    Output = U256,
-    NewTaskEvent = NewTaskCreated,
-    TaskRespondedEvent = TaskResponded,
-);
-
+// Implement the [`TaskManagerDefs`] trait for a unit struct.
+// You need to specify the input and output types of the task. In this case, U256.
+// You also need to specify the selectors for the new task event and the task responded event.
 pub struct ISTaskManager;
 
 impl TaskManagerDefs for ISTaskManager {
@@ -40,3 +24,5 @@ impl TaskManagerDefs for ISTaskManager {
     const NEW_TASK_EVENT_SELECTOR: B256 = NewTaskCreated::SIGNATURE_HASH;
     const TASK_RESPONDED_EVENT_SELECTOR: B256 = TaskResponded::SIGNATURE_HASH;
 }
+
+impl_task_manager_from_defs_and_contract!(ISTaskManager => IncredibleSquaringTaskManagerInstance);

--- a/examples/incredible-squaring/src/lib.rs
+++ b/examples/incredible-squaring/src/lib.rs
@@ -1,10 +1,13 @@
 //! Example AVS which squares a number
 
+use alloy::primitives::B256;
 use alloy::primitives::U256;
+use alloy::sol_types::SolEvent;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::IncredibleSquaringTaskManagerInstance;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::NewTaskCreated;
 use bindings::incrediblesquaringtaskmanager::IncredibleSquaringTaskManager::TaskResponded;
 use eigen_task_processor::impl_task_manager;
+use eigen_task_processor::task_manager::TaskManagerDefs;
 
 // Allow warnings in auto-generated code
 #[allow(warnings)]
@@ -28,3 +31,12 @@ impl_task_manager!(
     NewTaskEvent = NewTaskCreated,
     TaskRespondedEvent = TaskResponded,
 );
+
+pub struct ISTaskManager;
+
+impl TaskManagerDefs for ISTaskManager {
+    type Input = U256;
+    type Output = U256;
+    const NEW_TASK_EVENT_SELECTOR: B256 = NewTaskCreated::SIGNATURE_HASH;
+    const TASK_RESPONDED_EVENT_SELECTOR: B256 = TaskResponded::SIGNATURE_HASH;
+}


### PR DESCRIPTION
Fixes #

### What Changed?

This PR splits the `TaskManager` trait into `TaskManagerDefs`, which includes type definitions and constants, and the `TaskManager` trait which requires the `Defs` and implements the other methods.

This simplifies the macro by reducing its parameters to a type implementing `TaskManagerDefs`, and another which is an Alloy contract instance.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
