### PR TITLE
chore: bump workspace version to v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,7 +2065,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chainio-integration-test"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "ark-ff 0.5.0",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-cli"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "ark-ec 0.5.0",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-client-avsregistry"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "ark-ff 0.5.0",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-client-elcontracts"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "eigen-common",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-client-eth"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-client-fireblocks"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "chrono",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-common"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "url",
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-crypto-bls"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "ark-bn254 0.5.0",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-crypto-bn254"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ec 0.5.0",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-logging"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "ctor",
  "once_cell",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-metrics"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "eigen-client-avsregistry",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-metrics-collectors-economic"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "eigen-client-avsregistry",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-metrics-collectors-rpc-calls"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "eigen-logging",
  "metrics",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-nodeapi"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "ntex",
  "reqwest 0.12.15",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-services-avsregistry"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "ark-bn254 0.5.0",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-services-blsaggregation"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "ark-bn254 0.5.0",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-services-operatorsinfo"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "ark-bn254 0.5.0",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-signer"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-testing-utils"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "eigen-client-avsregistry",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-types"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "ark-bn254 0.5.0",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "eigen-utils"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "regex",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "eigensdk"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "eigen-client-avsregistry",
  "eigen-client-elcontracts",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "examples-anvil-utils"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "eigen-client-avsregistry",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "examples-avsregistry-read"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "eigen-client-avsregistry",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "examples-avsregistry-write"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "ark-bn254 0.4.0",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "info-operator-service"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "alloy",
  "eigen-client-avsregistry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0-rc.0"
+version = "1.0.0"
 edition = "2021"
 authors = ["Eigen Layer contributors"]
 rust-version = "1.81"
@@ -60,25 +60,25 @@ clippy.implicit_return = "allow"
 
 [workspace.dependencies]
 # eigensdk
-eigen-common = { version = "1.0.0-rc.0", path = "crates/common/" }
-eigen-client-elcontracts = { version = "1.0.0-rc.0", path = "crates/chainio/clients/elcontracts" }
-eigen-client-avsregistry = { version = "1.0.0-rc.0", path = "crates/chainio/clients/avsregistry" }
-eigen-client-eth = { version = "1.0.0-rc.0", path = "crates/chainio/clients/eth" }
-eigen-client-fireblocks = { version = "1.0.0-rc.0", path = "crates/chainio/clients/fireblocks" }
-eigen-crypto-bls = { version = "1.0.0-rc.0", path = "crates/crypto/bls/" }
-eigen-crypto-bn254 = { version = "1.0.0-rc.0", path = "crates/crypto/bn254/" }
-eigen-logging = { version = "1.0.0-rc.0", path = "crates/logging/" }
-eigen-metrics = { version = "1.0.0-rc.0", path = "crates/metrics/" }
-eigen-metrics-collectors-economic = { version = "1.0.0-rc.0", path = "crates/metrics/collectors/economic" }
-eigen-metrics-collectors-rpc-calls = { version = "1.0.0-rc.0", path = "crates/metrics/collectors/rpc_calls" }
-eigen-services-avsregistry = { version = "1.0.0-rc.0", path = "crates/services/avsregistry" }
-eigen-services-blsaggregation = { version = "1.0.0-rc.0", path = "crates/services/bls_aggregation" }
-eigen-services-operatorsinfo = { version = "1.0.0-rc.0", path = "crates/services/operatorsinfo" }
-eigen-signer = { version = "1.0.0-rc.0", path = "crates/signer/" }
-eigen-types = { version = "1.0.0-rc.0", path = "crates/types/" }
-eigen-utils = { version = "1.0.0-rc.0", path = "crates/utils/" }
-eigen-nodeapi = { version = "1.0.0-rc.0", path = "crates/nodeapi/" }
-eigen-testing-utils = { version = "1.0.0-rc.0", path = "tests/testing-utils" }
+eigen-common = { version = "1.0.0", path = "crates/common/" }
+eigen-client-elcontracts = { version = "1.0.0", path = "crates/chainio/clients/elcontracts" }
+eigen-client-avsregistry = { version = "1.0.0", path = "crates/chainio/clients/avsregistry" }
+eigen-client-eth = { version = "1.0.0", path = "crates/chainio/clients/eth" }
+eigen-client-fireblocks = { version = "1.0.0", path = "crates/chainio/clients/fireblocks" }
+eigen-crypto-bls = { version = "1.0.0", path = "crates/crypto/bls/" }
+eigen-crypto-bn254 = { version = "1.0.0", path = "crates/crypto/bn254/" }
+eigen-logging = { version = "1.0.0", path = "crates/logging/" }
+eigen-metrics = { version = "1.0.0", path = "crates/metrics/" }
+eigen-metrics-collectors-economic = { version = "1.0.0", path = "crates/metrics/collectors/economic" }
+eigen-metrics-collectors-rpc-calls = { version = "1.0.0", path = "crates/metrics/collectors/rpc_calls" }
+eigen-services-avsregistry = { version = "1.0.0", path = "crates/services/avsregistry" }
+eigen-services-blsaggregation = { version = "1.0.0", path = "crates/services/bls_aggregation" }
+eigen-services-operatorsinfo = { version = "1.0.0", path = "crates/services/operatorsinfo" }
+eigen-signer = { version = "1.0.0", path = "crates/signer/" }
+eigen-types = { version = "1.0.0", path = "crates/types/" }
+eigen-utils = { version = "1.0.0", path = "crates/utils/" }
+eigen-nodeapi = { version = "1.0.0", path = "crates/nodeapi/" }
+eigen-testing-utils = { version = "1.0.0", path = "tests/testing-utils" }
 
 ark-bn254 = "0.5.0"
 ark-ec = "0.5.0"


### PR DESCRIPTION
Fixes #

### What Changed?

This PR bumps the workspace version to v1.0.0

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
