### PR TITLE
refactor(v2): move `get_non_signing_operator_pubkeys` into `aggregator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,6 +2734,7 @@ name = "eigen-aggregator"
 version = "0.5.0"
 dependencies = [
  "alloy",
+ "ark-ec 0.5.0",
  "eigen-client-avsregistry",
  "eigen-common",
  "eigen-crypto-bls",

--- a/crates/aggregator/Cargo.toml
+++ b/crates/aggregator/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 alloy.workspace = true
+ark-ec.workspace = true
 eigen-types.workspace = true
 serde.workspace = true
 eigen-crypto-bls.workspace = true

--- a/crates/aggregator/src/error.rs
+++ b/crates/aggregator/src/error.rs
@@ -1,5 +1,6 @@
 use alloy::transports::{RpcError, TransportErrorKind};
 use eigen_client_avsregistry::error::AvsRegistryError;
+use eigen_crypto_bls::error::BlsError;
 use eigen_services_blsaggregation::bls_aggregation_service_error::BlsAggregationServiceError;
 use eigen_services_operatorsinfo::operatorsinfo_inmemory::OperatorInfoServiceError;
 use eigen_task_processor::error::TaskProcessorError;
@@ -55,4 +56,8 @@ pub enum AggregatorError {
     /// Task processor error
     #[error("Task processor error")]
     IndexingTaskProcessorError(#[from] TaskProcessorError),
+
+    /// Point conversion error
+    #[error("Point conversion error")]
+    PointConversionError(#[from] BlsError),
 }

--- a/crates/aggregator/src/lib.rs
+++ b/crates/aggregator/src/lib.rs
@@ -15,9 +15,11 @@ use alloy::providers::Provider;
 use alloy::providers::{ProviderBuilder, WsConnect};
 use alloy::rpc::types::{Filter, Log};
 use alloy::sol_types::SolValue;
+use ark_ec::AffineRepr;
 pub use config::AggregatorConfig;
 use eigen_client_avsregistry::reader::AvsRegistryChainReader;
 use eigen_common::get_ws_provider;
+use eigen_crypto_bls::{convert_to_g1_point, convert_to_g2_point};
 use eigen_logging::get_logger;
 use eigen_services_avsregistry::chaincaller::AvsRegistryServiceChainCaller;
 use eigen_services_blsaggregation::bls_agg::{
@@ -29,6 +31,10 @@ pub use eigen_services_blsaggregation::{
 use eigen_services_operatorsinfo::operatorsinfo_inmemory::OperatorInfoServiceInMemory;
 use eigen_task_processor::task::Task;
 use eigen_task_processor::task_processor::TaskProcessor;
+use eigen_utils::slashing::middleware::{
+    iblssignaturechecker::IBLSSignatureCheckerTypes::NonSignerStakesAndSignature,
+    iblssignaturechecker::BN254::{G1Point, G2Point},
+};
 pub use error::AggregatorError;
 use futures_util::{future, StreamExt};
 use rpc_server::{ProcessSignedTaskResponse, ProcessSignedTaskResponseServer};
@@ -255,8 +261,15 @@ where
                 .receive_aggregated_response()
                 .await?;
 
+            let non_signing_operator_pubkeys =
+                get_non_signing_operator_pubkeys(service_response.clone())?;
+
             task_processor
-                .process_aggregated_response(service_response)
+                .process_aggregated_response(
+                    service_response.task_index,
+                    service_response.task_response_digest,
+                    non_signing_operator_pubkeys,
+                )
                 .await?;
         }
     }
@@ -314,4 +327,56 @@ where
             },
         ))
     }
+}
+
+/// Build the [`NonSignerStakesAndSignature`] struct from the [`BlsAggregationServiceResponse`]
+///
+/// # Arguments
+///
+/// * `response` - The response of the BLS aggregation service
+///
+/// # Returns
+///
+/// * `Result<NonSignerStakesAndSignature, AggregatorError>` - The non-signing operator pub keys
+fn get_non_signing_operator_pubkeys(
+    response: BlsAggregationServiceResponse,
+) -> Result<NonSignerStakesAndSignature, AggregatorError> {
+    let mut non_signer_pub_keys = Vec::<G1Point>::new();
+    for pub_key in response.non_signers_pub_keys_g1.iter() {
+        if pub_key.g1().x().is_some() {
+            let g1 = convert_to_g1_point(pub_key.g1())?;
+            non_signer_pub_keys.push(G1Point { X: g1.X, Y: g1.Y })
+        } else {
+            info!(
+                "Zero non_signers for the task index :{:?}",
+                response.task_index
+            );
+        }
+    }
+
+    let mut quorum_apks = Vec::<G1Point>::new();
+    for pub_key in response.quorum_apks_g1.iter() {
+        let g1 = convert_to_g1_point(pub_key.g1())?;
+        quorum_apks.push(G1Point { X: g1.X, Y: g1.Y })
+    }
+
+    let apk_g2 = convert_to_g2_point(response.signers_apk_g2.g2())?;
+    let sigma = convert_to_g1_point(response.signers_agg_sig_g1.g1_point().g1())?;
+
+    Ok(NonSignerStakesAndSignature {
+        nonSignerPubkeys: non_signer_pub_keys,
+        nonSignerQuorumBitmapIndices: response.non_signer_quorum_bitmap_indices,
+        quorumApks: quorum_apks,
+        apkG2: G2Point {
+            X: apk_g2.X,
+            Y: apk_g2.Y,
+        },
+        sigma: G1Point {
+            X: sigma.X,
+            Y: sigma.Y,
+        },
+        quorumApkIndices: response.quorum_apk_indices,
+        totalStakeIndices: response.total_stake_indices,
+        nonSignerStakeIndices: response.non_signer_stake_indices,
+    })
 }

--- a/crates/aggregator/src/lib.rs
+++ b/crates/aggregator/src/lib.rs
@@ -19,6 +19,7 @@ use ark_ec::AffineRepr;
 pub use config::AggregatorConfig;
 use eigen_client_avsregistry::reader::AvsRegistryChainReader;
 use eigen_common::get_ws_provider;
+use eigen_crypto_bls::error::BlsError;
 use eigen_crypto_bls::{convert_to_g1_point, convert_to_g2_point};
 use eigen_logging::get_logger;
 use eigen_services_avsregistry::chaincaller::AvsRegistryServiceChainCaller;
@@ -340,7 +341,7 @@ where
 /// * `Result<NonSignerStakesAndSignature, AggregatorError>` - The non-signing operator pub keys
 fn get_non_signing_operator_pubkeys(
     response: BlsAggregationServiceResponse,
-) -> Result<NonSignerStakesAndSignature, AggregatorError> {
+) -> Result<NonSignerStakesAndSignature, BlsError> {
     let mut non_signer_pub_keys = Vec::<G1Point>::new();
     for pub_key in response.non_signers_pub_keys_g1.iter() {
         if pub_key.g1().x().is_some() {

--- a/crates/task-processor/src/error.rs
+++ b/crates/task-processor/src/error.rs
@@ -1,4 +1,3 @@
-use eigen_crypto_bls::error::BlsError;
 use thiserror::Error;
 
 use crate::task_manager::TaskManagerError;
@@ -13,10 +12,6 @@ pub enum TaskProcessorError {
     /// Task response not found
     #[error("Task response not found")]
     TaskResponseNotFound,
-
-    /// Error de conversión de puntos G1/G2
-    #[error("Error de conversión de puntos G1/G2")]
-    PointConversionError(#[from] BlsError),
 
     /// Task manager error
     #[error("Task manager error")]

--- a/crates/task-processor/src/lib.rs
+++ b/crates/task-processor/src/lib.rs
@@ -1,16 +1,9 @@
 //! Task manager
 
 use alloy::primitives::B256;
-use ark_ec::AffineRepr;
-use eigen_crypto_bls::{convert_to_g1_point, convert_to_g2_point};
-use eigen_services_blsaggregation::{
-    bls_agg::TaskMetadata, bls_aggregation_service_response::BlsAggregationServiceResponse,
-};
+use eigen_services_blsaggregation::bls_agg::TaskMetadata;
 use eigen_types::avs::TaskResponseDigest;
-use eigen_utils::slashing::middleware::{
-    iblssignaturechecker::IBLSSignatureCheckerTypes::NonSignerStakesAndSignature,
-    iblssignaturechecker::BN254::{G1Point, G2Point},
-};
+use eigen_utils::slashing::middleware::iblssignaturechecker::IBLSSignatureCheckerTypes::NonSignerStakesAndSignature;
 use error::TaskProcessorError;
 use std::sync::Arc;
 use std::time::Duration;
@@ -129,63 +122,26 @@ where
 
     async fn process_aggregated_response(
         &self,
-        response: BlsAggregationServiceResponse,
+        task_index: u32,
+        task_response_digest: B256,
+        non_signer_stakes_and_signature: NonSignerStakesAndSignature,
     ) -> Result<(), TaskProcessorError> {
         info!(
             "Aggregated response received for task {}: {:?}",
-            response.task_index, response.task_response_digest
+            task_index, task_response_digest
         );
-
-        let mut non_signer_pub_keys = Vec::<G1Point>::new();
-        for pub_key in response.non_signers_pub_keys_g1.iter() {
-            if pub_key.g1().x().is_some() {
-                let g1 = convert_to_g1_point(pub_key.g1())?;
-                non_signer_pub_keys.push(G1Point { X: g1.X, Y: g1.Y })
-            } else {
-                info!(
-                    "Zero non_signers for the task index :{:?}",
-                    response.task_index
-                );
-            }
-        }
-
-        let mut quorum_apks = Vec::<G1Point>::new();
-        for pub_key in response.quorum_apks_g1.iter() {
-            let g1 = convert_to_g1_point(pub_key.g1())?;
-            quorum_apks.push(G1Point { X: g1.X, Y: g1.Y })
-        }
-
-        let apk_g2 = convert_to_g2_point(response.signers_apk_g2.g2())?;
-        let sigma = convert_to_g1_point(response.signers_agg_sig_g1.g1_point().g1())?;
-
-        let non_signer_stakes_and_signature = NonSignerStakesAndSignature {
-            nonSignerPubkeys: non_signer_pub_keys,
-            nonSignerQuorumBitmapIndices: response.non_signer_quorum_bitmap_indices,
-            quorumApks: quorum_apks,
-            apkG2: G2Point {
-                X: apk_g2.X,
-                Y: apk_g2.Y,
-            },
-            sigma: G1Point {
-                X: sigma.X,
-                Y: sigma.Y,
-            },
-            quorumApkIndices: response.quorum_apk_indices,
-            totalStakeIndices: response.total_stake_indices,
-            nonSignerStakeIndices: response.non_signer_stake_indices,
-        };
 
         let (task, task_response) = {
             let tasks_lock = self.tasks.lock().await;
             let task = tasks_lock
-                .get(&response.task_index)
+                .get(&task_index)
                 .ok_or(TaskProcessorError::TaskNotFound)?
                 .clone();
 
             let responses_lock = self.task_responses.lock().await;
             let task_response = responses_lock
-                .get(&response.task_index)
-                .and_then(|map| map.get(&response.task_response_digest))
+                .get(&task_index)
+                .and_then(|map| map.get(&task_response_digest))
                 .ok_or(TaskProcessorError::TaskResponseNotFound)?
                 .clone();
 

--- a/crates/task-processor/src/task_processor.rs
+++ b/crates/task-processor/src/task_processor.rs
@@ -1,7 +1,6 @@
 use alloy::{primitives::B256, sol_types::SolValue};
-use eigen_services_blsaggregation::{
-    bls_agg::TaskMetadata, bls_aggregation_service_response::BlsAggregationServiceResponse,
-};
+use eigen_services_blsaggregation::bls_agg::TaskMetadata;
+use eigen_utils::slashing::middleware::iblssignaturechecker::IBLSSignatureCheckerTypes::NonSignerStakesAndSignature;
 use serde::de::DeserializeOwned;
 use std::future::Future;
 
@@ -61,6 +60,8 @@ pub trait TaskProcessor {
     /// The aggregated response digest
     fn process_aggregated_response(
         &self,
-        response: BlsAggregationServiceResponse,
+        task_index: u32,
+        task_response_digest: B256,
+        non_signer_stakes_and_signature: NonSignerStakesAndSignature,
     ) -> impl Future<Output = Result<(), TaskProcessorError>> + Send;
 }


### PR DESCRIPTION
### What Changed?
This PR moves the logic for obtaining non-signing operator public keys from the `IndexingTaskProcessor` into the `aggregator`. With this change, users no longer need to implement it themselves. 

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
