### PR TITLE
feat(v2): disable `tarpc` logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4944,7 +4944,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -4958,7 +4958,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -5058,6 +5058,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -5795,7 +5804,7 @@ checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
 dependencies = [
  "parse-display-derive",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5807,7 +5816,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "structmeta",
  "syn 2.0.100",
 ]
@@ -6135,7 +6144,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -6343,8 +6352,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -6355,7 +6373,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -6363,6 +6381,12 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -8091,12 +8115,16 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ testcontainers = "0.23"
 thiserror = "1.0"
 tokio = { version = "1.41", features = ["test-util", "full", "sync"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["json"] }
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 url = "2.5"
 
 #misc

--- a/crates/logging/src/tracing_logger.rs
+++ b/crates/logging/src/tracing_logger.rs
@@ -2,6 +2,7 @@ use super::log_level::LogLevel;
 use super::logger::Logger;
 use std::{fmt::Debug, sync::Arc};
 use tracing::{debug, error, info, trace, warn};
+use tracing_subscriber::EnvFilter;
 
 // SLoggerOptions are options when creating a new SLogger.
 // A zero Options consists entirely of default values.
@@ -35,13 +36,19 @@ impl TracingLogger {
             LogLevel::Debug => tracing::Level::DEBUG,
             LogLevel::Trace => tracing::Level::TRACE,
         };
-        tracing::subscriber::set_global_default(
-            tracing_subscriber::fmt::Subscriber::builder()
-                .with_max_level(tracing_level)
-                .with_ansi(no_color)
-                .finish(),
-        )
-        .expect("setting default subscriber failed");
+
+        // Disable tarpc logging
+        let mut filter = EnvFilter::new("tarpc=off");
+        // Set the default level for all other loggers
+        filter = filter.add_directive(tracing_level.into());
+
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(no_color)
+            .with_env_filter(filter)
+            .finish();
+
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("setting default subscriber failed");
 
         Arc::new(TracingLogger {
             add_source,


### PR DESCRIPTION
Fixes #

### What Changed?
This PR disables `tarpc` logs because they are too verbose.

We also remove the call to `with_max_level()`, since using it alongside `with_env_filter()` (in either order) causes the second call to overwrite the former.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
