### PR TITLE
refactor(v2): use `bls_private_key` instead of `bls_key_pair` in operator config

### DIFF
--- a/crates/operator/src/config.rs
+++ b/crates/operator/src/config.rs
@@ -1,13 +1,12 @@
 use super::register_config::OperatorRegistrationConfig;
 use alloy::primitives::Address;
-use eigen_crypto_bls::BlsKeyPair;
 use serde::{Deserialize, Serialize};
 
 /// Operator configuration struct
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OperatorConfig {
     /// BLS key pair of the operator
-    pub bls_key_pair: BlsKeyPair,
+    pub bls_private_key: String,
     /// Address of the operator
     pub operator_address: Address,
     /// Name of the operator

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -64,7 +64,7 @@ impl Operator {
         config: config::OperatorConfig,
     ) -> Result<Self, OperatorError> {
         let config::OperatorConfig {
-            bls_key_pair,
+            bls_private_key,
             operator_address,
             operator_name,
             ws_rpc_url,
@@ -99,12 +99,14 @@ impl Operator {
             .await
             .map_err(|_| OperatorError::OperatorIdError)?;
 
+        let key_pair = BlsKeyPair::new(bls_private_key)?;
+
         Ok(Self {
             operator_id,
             operator_name: operator_name.to_string(),
             ws_rpc_url: ws_rpc_url.to_string(),
             client_aggregator: client_aggregator.clone(),
-            key_pair: bls_key_pair.clone(),
+            key_pair,
         })
     }
 

--- a/examples/awesome-vault-service/src/bin/operator.rs
+++ b/examples/awesome-vault-service/src/bin/operator.rs
@@ -22,7 +22,7 @@ use tracing::info;
 #[tokio::main]
 async fn main() {
     init_logger(LogLevel::Info);
-    let bls_key_pair = BlsKeyPair::new(OPERATOR_BLS_KEY.to_string()).unwrap();
+    let bls_private_key = OPERATOR_BLS_KEY.to_string();
     let operator_address = FIRST_ADDRESS;
     let operator_private_key = FIRST_PRIVATE_KEY;
     let operator_name = "dot-product-god";
@@ -50,7 +50,7 @@ async fn main() {
         Address::from_str("0x4c5859f0f772848b2d91f1d83e2fe57935348029").unwrap();
 
     setup_operator(
-        bls_key_pair.clone(),
+        BlsKeyPair::new(bls_private_key.clone()).unwrap(),
         Some(operator_private_key.to_string()),
         "ecdsa_keystore_path".to_string(),
         "ecdsa_keystore_password".to_string(),
@@ -77,7 +77,7 @@ async fn main() {
     info!("Operator setup complete");
 
     let operator_config = OperatorConfig {
-        bls_key_pair,
+        bls_private_key,
         operator_address,
         operator_name: operator_name.to_string(),
         ws_rpc_url: ws_rpc_url.to_string(),

--- a/examples/incredible-dot-product/src/bin/operator.rs
+++ b/examples/incredible-dot-product/src/bin/operator.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
     info!("Operator setup complete");
 
     let operator_config = OperatorConfig {
-        bls_key_pair,
+        bls_private_key: OPERATOR_BLS_KEY.to_string(),
         operator_address,
         operator_name: operator_name.to_string(),
         ws_rpc_url: ws_rpc_url.to_string(),

--- a/examples/incredible-squaring/src/bin/operator.rs
+++ b/examples/incredible-squaring/src/bin/operator.rs
@@ -1,7 +1,6 @@
 #![allow(missing_docs)]
 
 use alloy::primitives::{address, U256};
-use eigen_crypto_bls::BlsKeyPair;
 use eigen_logging::get_logger;
 use eigen_operator::{config::OperatorConfig, failing_response_calculator, Operator};
 use eigen_testing_utils::anvil_constants::{FIRST_ADDRESS, OPERATOR_BLS_KEY};
@@ -18,10 +17,8 @@ async fn main() {
     let ws_rpc_url = "ws://localhost:8545".to_string();
     let logger = get_logger();
 
-    let bls_key_pair = BlsKeyPair::new(OPERATOR_BLS_KEY.to_string()).unwrap();
-
     let config = OperatorConfig {
-        bls_key_pair,
+        bls_private_key: OPERATOR_BLS_KEY.to_string(),
         operator_address: FIRST_ADDRESS,
         operator_name: "OPERATOR NAME".to_string(),
         ws_rpc_url,


### PR DESCRIPTION
Fixes #

### What Changed?
This PR updates the operator config from BlsKeyPair to string. Now we need the BLS PK.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
