### PR TITLE
fix: update binaries and init submodules at README files

### DIFF
--- a/examples/awesome-vault-service/README.md
+++ b/examples/awesome-vault-service/README.md
@@ -49,6 +49,12 @@ To feed inputs into the task spammer, we define an iterator in `examples/awesome
 
 This simple session illustrates the basic flow of the AVS:
 
+Initialize the Middleware and Forge submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
 Start anvil in a separate terminal:
 
 ```bash

--- a/examples/awesome-vault-service/README.md
+++ b/examples/awesome-vault-service/README.md
@@ -70,13 +70,13 @@ make deploy-el-and-avs-contracts
 Start the aggregator:
 
 ```bash
-cargo run --bin aggregator
+cargo run --bin awesome-vault-aggregator
 ```
 
 Start the operator:
 
 ```bash
-cargo run --bin operator
+cargo run --bin awesome-vault-operator
 ```
 
 The Operator will first check whether it is already registered on EigenLayer. If not, it will attempt to register automatically. To enable registration, create an [OperatorRegistrationConfig] and include it in the [OperatorConfig] struct.
@@ -86,11 +86,11 @@ The operator will produce invalid results often because it use `failing_response
 These failures result in slashing once they're challenged. To see this in action, start the challenger with:
 
 ```bash
-cargo run --bin challenger
+cargo run --bin awesome-vault-challenger
 ```
 
 To start the cycle, start the task spammer:
 
 ``` bash
-cargo run --bin task-spammer
+cargo run --bin awesome-vault-task-spammer
 ```

--- a/examples/incredible-dot-product/README.md
+++ b/examples/incredible-dot-product/README.md
@@ -68,13 +68,13 @@ make deploy-el-and-avs-contracts
 Start the aggregator:
 
 ```bash
-cargo run --bin aggregator
+cargo run --bin incredible-dot-aggregator
 ```
 
 Start the operator:
 
 ```bash
-cargo run --bin operator
+cargo run --bin incredible-dot-operator
 ```
 
 The Operator will first check whether it is already registered on EigenLayer. If not, it will attempt to register automatically. To enable registration, create an [OperatorRegistrationConfig] and include it in the [OperatorConfig] struct.
@@ -84,11 +84,11 @@ The operator will produce invalid results often because it use `failing_response
 These failures result in slashing once they're challenged. To see this in action, start the challenger with:
 
 ```bash
-cargo run --bin challenger
+cargo run --bin incredible-dot-challenger
 ```
 
 To start the cycle, start the task spammer:
 
 ``` bash
-cargo run --bin task-spammer
+cargo run --bin incredible-dot-task-spammer
 ```

--- a/examples/incredible-dot-product/README.md
+++ b/examples/incredible-dot-product/README.md
@@ -47,6 +47,12 @@ To create the sequence that passes input values to the task spammer, we use the 
 
 This simple session illustrates the basic flow of the AVS:
 
+Initialize the Middleware and Forge submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
 Start anvil in a separate terminal:
 
 ```bash


### PR DESCRIPTION
### What Changed?
This PR adds a git submodule init reminder and updates the names of the binaries on the dot product and vault service examples.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
