### PR TITLE
fix(v2): avoid end loop when `receive_aggregated_response` return an error

### DIFF
--- a/crates/aggregator/src/lib.rs
+++ b/crates/aggregator/src/lib.rs
@@ -154,7 +154,7 @@ use std::net::SocketAddr;
 use tarpc::server::{self, Channel};
 use tarpc::tokio_serde::formats::Json;
 use task_processor::TaskProcessor;
-use tracing::info;
+use tracing::{error, info};
 
 /// The aggregator is responsible for aggregating [`SignedTaskResponse`] from operators and posting them on chain. This includes:
 ///
@@ -381,9 +381,14 @@ where
         mut aggregated_response_receiver: AggregateReceiver,
     ) -> Result<(), AggregatorError> {
         loop {
-            let service_response = aggregated_response_receiver
+            let Ok(service_response) = aggregated_response_receiver
                 .receive_aggregated_response()
-                .await?;
+                .await
+                .inspect_err(|e| error!("Error receiving aggregated response: {}", e))
+            else {
+                // If the receiver channel is closed, we continue to the next loop
+                continue;
+            };
 
             let non_signing_operator_pubkeys =
                 get_non_signing_operator_pubkeys(service_response.clone())?;


### PR DESCRIPTION
### What Changed?
Our `process_aggregated_signatures` loop would terminate when `receive_aggregated_response` returned an error (for example, “task expired”), which closed the BLS Aggregation channel.

```
2025-05-29T14:27:38.875747Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 0
2025-05-29T14:27:43.878863Z ERROR eigen_aggregator: Error receiving aggregated response: task expired error
2025-05-29T14:27:48.881149Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 1
2025-05-29T14:27:58.888121Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 2
2025-05-29T14:28:08.895076Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 3
2025-05-29T14:28:18.901817Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 4
2025-05-29T14:28:28.907993Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 5
2025-05-29T14:28:38.914849Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 6
2025-05-29T14:28:48.921539Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 7
2025-05-29T14:28:48.924806Z  INFO eigen_aggregator::rpc_server: Received signed task response for task index 7
Error with single_task_aggregator: SenderError
```

Now we print the error and continue to the next iteration so the loop never exits.

```
2025-05-29T14:37:21.196377Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 0
2025-05-29T14:37:26.201857Z ERROR eigen_aggregator: Error receiving aggregated response: task expired error
2025-05-29T14:37:31.202899Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 1
2025-05-29T14:37:36.208045Z ERROR eigen_aggregator: Error receiving aggregated response: task expired error
2025-05-29T14:37:41.208981Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 2
2025-05-29T14:37:46.214412Z ERROR eigen_aggregator: Error receiving aggregated response: task expired error
2025-05-29T14:37:51.214798Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 3
2025-05-29T14:37:56.220372Z ERROR eigen_aggregator: Error receiving aggregated response: task expired error
2025-05-29T14:38:01.221526Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 4
2025-05-29T14:38:06.226504Z ERROR eigen_aggregator: Error receiving aggregated response: task expired error
2025-05-29T14:38:11.227827Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 5
2025-05-29T14:38:11.230851Z  INFO eigen_aggregator::rpc_server: Received signed task response for task index 5
2025-05-29T14:38:12.282260Z  INFO eigen_aggregator: Received an aggregated response for task index 5
2025-05-29T14:38:12.282326Z  INFO eigen_aggregator::task_processor::indexing_task_processor: Aggregated response received for task 5: 0xef6a8f673ca5476c495d0ab5aa04e3cd3d07628b2ff5d0e5202b94c5c6f13bdc
2025-05-29T14:38:12.594259Z  INFO eigen_aggregator::task_processor::indexing_task_processor: Aggregated response sent to contract
2025-05-29T14:38:21.246491Z  INFO eigen_aggregator: Detected NewTaskCreated event for index 6
2025-05-29T14:38:21.249457Z  INFO eigen_aggregator::rpc_server: Received signed task response for task index 6
2025-05-29T14:38:22.301853Z  INFO eigen_aggregator: Received an aggregated response for task index 6
```

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
