### PR TITLE
refactor(v2): remove `operator_state_retriever_address` from `OperatorConfig`

### DIFF
--- a/crates/operator/src/config.rs
+++ b/crates/operator/src/config.rs
@@ -19,8 +19,6 @@ pub struct OperatorConfig {
     /// Address of the registry coordinator
     /// Used to check the operator is registered.
     pub registry_coordinator_address: Address,
-    /// Address of the operator state retriever
-    pub operator_state_retriever_address: Address,
     /// IP and port of the aggregator
     pub aggregator_ip_port: String,
     /// Operator registration config

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -129,7 +129,7 @@
 
 use alloy::{
     dyn_abi::SolType,
-    primitives::keccak256,
+    primitives::{keccak256, Address},
     providers::{Provider, ProviderBuilder, WsConnect},
     rpc::types::Filter,
     sol_types::SolValue,
@@ -195,14 +195,15 @@ impl Operator {
             ws_rpc_url,
             http_rpc_url,
             registry_coordinator_address,
-            operator_state_retriever_address,
             aggregator_ip_port,
             registration: _,
         } = config;
         let avs_registry_reader = AvsRegistryChainReader::new(
             logger.clone(),
             registry_coordinator_address,
-            operator_state_retriever_address,
+            // We don't need to use the operator state retriever address because we don't use methods
+            // that require the address of the contract
+            Address::ZERO,
             http_rpc_url.to_string(),
         )
         .await?;

--- a/examples/awesome-vault-service/src/config/awesome-operator.toml
+++ b/examples/awesome-vault-service/src/config/awesome-operator.toml
@@ -4,7 +4,6 @@ operator_name = "vault"
 http_rpc_url = "http://localhost:8545"
 ws_rpc_url = "ws://localhost:8545"
 registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
-operator_state_retriever_address = "0x4c5859f0f772848b2d91f1d83e2fe57935348029"
 aggregator_ip_port = "127.0.0.1:8080"
 
 [registration]

--- a/examples/incredible-dot-product/src/config/dot-operator.toml
+++ b/examples/incredible-dot-product/src/config/dot-operator.toml
@@ -4,7 +4,6 @@ operator_name = "dot-product"
 http_rpc_url = "http://localhost:8545"
 ws_rpc_url = "ws://localhost:8545"
 registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
-operator_state_retriever_address = "0x4c5859f0f772848b2d91f1d83e2fe57935348029"
 aggregator_ip_port = "127.0.0.1:8080"
 
 

--- a/examples/incredible-squaring/src/config/squaring-operator.toml
+++ b/examples/incredible-squaring/src/config/squaring-operator.toml
@@ -4,7 +4,6 @@ operator_name = "squaring"
 http_rpc_url = "http://localhost:8545"
 ws_rpc_url = "ws://localhost:8545"
 registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"
-operator_state_retriever_address = "0x4c5859f0f772848b2d91f1d83e2fe57935348029"
 aggregator_ip_port = "127.0.0.1:8080"
 
 


### PR DESCRIPTION
Fixes #

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
