### PR TITLE
refactor(v2): remove `AvsRegistryChainReader` from operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,6 +3018,7 @@ dependencies = [
  "eigen-aggregator",
  "eigen-client-avsregistry",
  "eigen-client-elcontracts",
+ "eigen-common",
  "eigen-crypto-bls",
  "eigen-crypto-bn254",
  "eigen-logging",

--- a/crates/operator/Cargo.toml
+++ b/crates/operator/Cargo.toml
@@ -20,6 +20,7 @@ eigen-aggregator.workspace = true
 eigen-client-avsregistry.workspace = true
 eigen-client-elcontracts.workspace = true
 eigen-crypto-bls.workspace = true
+eigen-common.workspace = true
 eigen-task-manager.workspace = true
 eigen-types.workspace = true
 rust-bls-bn254.workspace = true

--- a/crates/operator/src/config.rs
+++ b/crates/operator/src/config.rs
@@ -19,8 +19,6 @@ pub struct OperatorConfig {
     /// Address of the registry coordinator
     /// Used to check the operator is registered.
     pub registry_coordinator_address: Address,
-    /// Address of the operator state retriever
-    pub operator_state_retriever_address: Address,
     /// IP and port of the aggregator
     pub aggregator_ip_port: String,
     /// Operator registration config

--- a/crates/operator/src/error.rs
+++ b/crates/operator/src/error.rs
@@ -1,7 +1,7 @@
+use alloy::contract::Error as AlloyError;
 use alloy::signers::local::LocalSignerError;
 use eigen_client_avsregistry::error::AvsRegistryError;
 use eigen_client_elcontracts::error::ElContractsError;
-// use eigen_config::error::ConfigError;
 use eigen_crypto_bls::error::BlsError;
 use eigen_task_manager::{event_decoder::AbiDecodeError, TaskManagerError};
 use rust_bls_bn254::errors::KeystoreError;
@@ -54,6 +54,9 @@ pub enum OperatorError {
     /// Invalid deposit tokens
     #[error("Invalid deposit tokens")]
     InvalidDepositTokens,
+    /// Alloy contract error
+    #[error("Alloy contract error: {0}")]
+    AlloyContractError(#[from] AlloyError),
     /// ELChainWriter Error
     #[error("ElContractsError Error")]
     ElContractsError(#[from] ElContractsError),

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -226,13 +226,13 @@ impl Operator {
             info!("Operator {} registered successfully", operator_name);
         }
 
+        let client_aggregator = ClientAggregator::new(aggregator_ip_port).await?;
+
         let operator_id = contract_registry_coordinator
             .getOperatorId(operator_address)
             .call()
             .await
             .map(|op| op._0)?;
-
-        let client_aggregator = ClientAggregator::new(aggregator_ip_port).await?;
 
         Ok(Self {
             operator_id,

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -136,12 +136,13 @@ use alloy::{
 };
 use client::ClientAggregator;
 use eigen_aggregator::SignedTaskResponse;
-use eigen_client_avsregistry::reader::AvsRegistryChainReader;
+use eigen_common::get_provider;
 use eigen_crypto_bls::BlsKeyPair;
 use eigen_logging::logger::SharedLogger;
 use eigen_task_manager::{event_decoder::decode_new_task, task_response::TaskResponse};
 use eigen_task_manager::{response_calculator::ResponseCalculator, TaskManagerDefs};
 use eigen_types::operator::OperatorId;
+use eigen_utils::slashing::middleware::registrycoordinator::RegistryCoordinator;
 use error::OperatorError;
 use futures_util::StreamExt;
 use registration::register_operator;
@@ -195,25 +196,23 @@ impl Operator {
             ws_rpc_url,
             http_rpc_url,
             registry_coordinator_address,
-            operator_state_retriever_address,
             aggregator_ip_port,
             registration: _,
         } = config;
-        let avs_registry_reader = AvsRegistryChainReader::new(
-            logger.clone(),
-            registry_coordinator_address,
-            operator_state_retriever_address,
-            http_rpc_url.to_string(),
-        )
-        .await?;
-
         let key_pair = BlsKeyPair::new(bls_private_key)?;
 
+        let provider = get_provider(&http_rpc_url);
+        let contract_registry_coordinator =
+            RegistryCoordinator::new(registry_coordinator_address, provider);
+
+        let is_operator_registered = contract_registry_coordinator
+            .getOperatorStatus(operator_address)
+            .call()
+            .await
+            .map(|op| op._0 == 1)?;
+
         // Check if the operator is registered with EigenLayer
-        if !avs_registry_reader
-            .is_operator_registered(operator_address)
-            .await?
-        {
+        if !is_operator_registered {
             // Check if a registration config was provided
             let Some(registration_config) = config.registration else {
                 error!(
@@ -227,12 +226,13 @@ impl Operator {
             info!("Operator {} registered successfully", operator_name);
         }
 
-        let client_aggregator = ClientAggregator::new(aggregator_ip_port).await?;
-
-        let operator_id = avs_registry_reader
-            .get_operator_id(operator_address)
+        let operator_id = contract_registry_coordinator
+            .getOperatorId(operator_address)
+            .call()
             .await
-            .map_err(|_| OperatorError::OperatorIdError)?;
+            .map(|op| op._0)?;
+
+        let client_aggregator = ClientAggregator::new(aggregator_ip_port).await?;
 
         Ok(Self {
             operator_id,

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -211,9 +211,10 @@ impl Operator {
             .await?
             ._0;
 
+        // 0 means the operator is not registered, 1 that they are
         let is_operator_registered = operator_status == 1;
 
-        // Check if the operator is registered with EigenLayer. 0 means the operator is not registered.
+        // Check if the operator is registered with EigenLayer
         if !is_operator_registered {
             // Check if a registration config was provided.
             let Some(registration_config) = config.registration else {

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -205,15 +205,17 @@ impl Operator {
         let contract_registry_coordinator =
             RegistryCoordinator::new(registry_coordinator_address, provider);
 
-        let is_operator_registered = contract_registry_coordinator
+        let operator_status = contract_registry_coordinator
             .getOperatorStatus(operator_address)
             .call()
-            .await
-            .map(|op| op._0 == 1)?;
+            .await?
+            ._0;
 
-        // Check if the operator is registered with EigenLayer
+        let is_operator_registered = operator_status == 1;
+
+        // Check if the operator is registered with EigenLayer. 0 means the operator is not registered.
         if !is_operator_registered {
-            // Check if a registration config was provided
+            // Check if a registration config was provided.
             let Some(registration_config) = config.registration else {
                 error!(
                     "Operator {} not registered and no registration config was provided",
@@ -231,8 +233,8 @@ impl Operator {
         let operator_id = contract_registry_coordinator
             .getOperatorId(operator_address)
             .call()
-            .await
-            .map(|op| op._0)?;
+            .await?
+            ._0;
 
         Ok(Self {
             operator_id,


### PR DESCRIPTION
Fixes #

### What Changed?
This PR removes `operator_state_retriever_address` from `OperatorConfig` and use the bindings contract to check if is registered or not instead of `AvsRegistryChainReader`

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
