### PR TITLE
feat(v2:) `signer` v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,10 +3124,10 @@ dependencies = [
  "eigen-testing-utils",
  "eth-keystore",
  "serde",
- "serde_json",
  "testcontainers",
  "thiserror 1.0.69",
  "tokio",
+ "toml",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,6 +3124,7 @@ dependencies = [
  "eigen-testing-utils",
  "eth-keystore",
  "serde",
+ "serde_json",
  "testcontainers",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -19,6 +19,6 @@ url.workspace = true
 
 [dev-dependencies]
 eigen-testing-utils.workspace = true
-serde_json.workspace = true
 testcontainers.workspace = true
 tokio.workspace = true
+toml = "0.8"

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -19,5 +19,6 @@ url.workspace = true
 
 [dev-dependencies]
 eigen-testing-utils.workspace = true
+serde_json.workspace = true
 testcontainers.workspace = true
 tokio.workspace = true

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -8,7 +8,7 @@ description = "aws,keystore,web3,private_key signers"
 license-file.workspace = true
 
 [dependencies]
-alloy.workspace = true
+alloy = { workspace = true, features = ["signer-keystore"] }
 async-trait.workspace = true
 aws-config = { workspace = true, features = ["behavior-version-latest"] }
 aws-sdk-kms.workspace = true

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -8,7 +8,7 @@ description = "aws,keystore,web3,private_key signers"
 license-file.workspace = true
 
 [dependencies]
-alloy = { workspace = true, features = ["signer-keystore"] }
+alloy.workspace = true
 async-trait.workspace = true
 aws-config = { workspace = true, features = ["behavior-version-latest"] }
 aws-sdk-kms.workspace = true

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -10,7 +10,7 @@ license-file.workspace = true
 [dependencies]
 alloy = { workspace = true, features = ["signer-keystore"] }
 async-trait.workspace = true
-aws-config.workspace = true
+aws-config = { workspace = true, features = ["behavior-version-latest"] }
 aws-sdk-kms.workspace = true
 eth-keystore.workspace = true
 serde.workspace = true

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -10,6 +10,7 @@ license-file.workspace = true
 [dependencies]
 alloy.workspace =true 
 async-trait.workspace = true
+aws-config.workspace = true
 aws-sdk-kms.workspace = true
 eth-keystore.workspace = true
 serde.workspace = true
@@ -17,7 +18,6 @@ thiserror.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-aws-config.workspace = true
 eigen-testing-utils.workspace = true
 testcontainers.workspace = true
 tokio.workspace = true

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -8,7 +8,7 @@ description = "aws,keystore,web3,private_key signers"
 license-file.workspace = true
 
 [dependencies]
-alloy.workspace =true 
+alloy = { workspace = true, features = ["signer-keystore"] }
 async-trait.workspace = true
 aws-config.workspace = true
 aws-sdk-kms.workspace = true

--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -9,7 +9,7 @@
 //! * [`signer`] - Legacy signer module.
 //! * [`signer_v2`] - New signer module that supports multiple signers. The difference between this
 //!   and the legacy signer is that this module is designed to be used in a more flexible way
-//!   and has a better interface to interact with.
+//!   and has a more intuitive interface.
 //! * [`web3_signer`] - Web3 signer module.
 
 pub mod signer;

--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -4,4 +4,5 @@
 )]
 
 pub mod signer;
+pub mod signer_v2;
 pub mod web3_signer;

--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -2,6 +2,15 @@
     html_logo_url = "https://github.com/Layr-Labs/eigensdk-rs/assets/91280922/bd13caec-3c00-4afc-839a-b83d2890beb5",
     issue_tracker_base_url = "https://github.com/Layr-Labs/eigensdk-rs/issues/"
 )]
+//! Signer module for EigenSDK.
+//!
+//! This module provides a set of traits and implementations for signing transactions.
+//!
+//! * [`signer`] - Legacy signer module.
+//! * [`signer_v2`] - New signer module that supports multiple signers. The difference between this
+//!   and the legacy signer is that this module is designed to be used in a more flexible way
+//!   and has a better interface to interact with.
+//! * [`web3_signer`] - Web3 signer module.
 
 pub mod signer;
 pub mod signer_v2;

--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -15,3 +15,5 @@
 pub mod signer;
 pub mod signer_v2;
 pub mod web3_signer;
+
+pub use signer_v2::*;

--- a/crates/signer/src/signer_v2/error.rs
+++ b/crates/signer/src/signer_v2/error.rs
@@ -9,7 +9,7 @@ pub enum SignerError {
     LocalSignerError(#[from] LocalSignerError),
     /// AwsSigner error
     #[error("aws signer error: {0}")]
-    AwsSignerError(#[from] AwsSignerError),
+    AwsSignerError(#[from] Box<AwsSignerError>),
     /// Invalid endpoint URL
     #[error("invalid endpoint URL")]
     InvalidEndpointUrl,

--- a/crates/signer/src/signer_v2/error.rs
+++ b/crates/signer/src/signer_v2/error.rs
@@ -1,7 +1,7 @@
 use alloy::signers::{aws::AwsSignerError, local::LocalSignerError};
 use thiserror::Error;
 
-/// Possible errors raised in signer creation
+/// Error returned when creating a signer
 #[derive(Error, Debug)]
 pub enum SignerError {
     /// LocalSigner error

--- a/crates/signer/src/signer_v2/error.rs
+++ b/crates/signer/src/signer_v2/error.rs
@@ -1,0 +1,13 @@
+use alloy::signers::{aws::AwsSignerError, local::LocalSignerError};
+use thiserror::Error;
+
+/// Possible errors raised in signer creation
+#[derive(Error, Debug)]
+pub enum SignerError {
+    /// LocalSigner error
+    #[error("local signer error: {0}")]
+    LocalSignerError(#[from] LocalSignerError),
+    /// AwsSigner error
+    #[error("aws signer error: {0}")]
+    AwsSignerError(#[from] AwsSignerError),
+}

--- a/crates/signer/src/signer_v2/error.rs
+++ b/crates/signer/src/signer_v2/error.rs
@@ -7,7 +7,8 @@ pub enum SignerError {
     /// LocalSigner error
     #[error("local signer error: {0}")]
     LocalSignerError(#[from] LocalSignerError),
-    /// AwsSigner error
+    /// AwsSigner error.
+    /// Boxed because [`AwsSignerError`] is much larger (344+ bytes) than other variants (32 bytes).
     #[error("aws signer error: {0}")]
     AwsSignerError(#[from] Box<AwsSignerError>),
     /// Invalid endpoint URL

--- a/crates/signer/src/signer_v2/error.rs
+++ b/crates/signer/src/signer_v2/error.rs
@@ -10,4 +10,7 @@ pub enum SignerError {
     /// AwsSigner error
     #[error("aws signer error: {0}")]
     AwsSignerError(#[from] AwsSignerError),
+    /// Invalid endpoint URL
+    #[error("invalid endpoint URL")]
+    InvalidEndpointUrl,
 }

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -203,9 +203,9 @@ pub enum SignerConfig {
     Keystore(KeystoreConfig),
     /// Web3 signer
     ///
-    /// Delegates transaction signing to an external signing service. The endpoint
-    /// URL must be a valid JSON-RPC endpoint.
-    ///
+    /// Delegates transaction signing to an external JSON-RPC signing service
+    /// compatible with the [Web3Signer](https://docs.web3signer.consensys.io/reference/api/json-rpc)
+    /// API. The service must support the `eth_signTransaction` method.
     Web3(Web3Config),
     /// AWS KMS signer
     ///
@@ -258,7 +258,7 @@ impl From<AwsConfig> for SignerConfig {
 /// Configuration for a private key signer
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PrivateKeyConfig {
-    /// Hexadecimal private key
+    /// Hex-encoded private key plaintext.
     pub private_key: String,
 }
 

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -281,6 +281,10 @@ pub struct KeystoreConfig {
 }
 
 /// Configuration for a web3 signer
+///
+/// Delegates transaction signing to an external JSON-RPC signing service
+/// compatible with the [Web3Signer](https://docs.web3signer.consensys.io/reference/api/json-rpc)
+/// API. The service must support the `eth_signTransaction` method.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Web3Config {
     /// Endpoint URL

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -28,9 +28,9 @@ pub enum SignerConfig {
     /// Keystore path and password
     /// Right now, only ECDSA keystore format is supported
     Keystore { path: String, password: String },
-    /// Web3Signer endpoint and address
+    /// Web3Signer
     Web3 { endpoint: String, address: Address },
-    /// AWS KMS key ID and chain ID
+    /// AWS KMS
     Aws {
         key_id: String,
         chain_id: Option<u64>,
@@ -41,7 +41,22 @@ pub enum SignerConfig {
     },
 }
 
+pub enum BlsKeySource {
+    /// Raw private key
+    PrivateKey { private_key_hex: String },
+    /// Keystore file + password
+    Keystore { path: String, password: String },
+}
+
 /// Creates a transaction signer from a configuration
+///
+/// # Arguments
+///
+/// * `config` - The signer configuration
+///
+/// # Returns
+///
+/// * A signer that implements the [`TxSigner`] trait
 pub async fn tx_signer_from_config(
     config: SignerConfig,
 ) -> Result<Box<dyn TxSigner<Signature>>, SignerError> {
@@ -50,7 +65,6 @@ pub async fn tx_signer_from_config(
             Ok(Box::new(PrivateKeySigner::from_str(&private_key_hex)?))
         }
         SignerConfig::Keystore { path, password } => {
-            // Support for ECDSA
             Ok(Box::new(LocalSigner::decrypt_keystore(path, password)?))
         }
         SignerConfig::Web3 { endpoint, address } => {

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -1,3 +1,5 @@
+//! Signer v2 module
+
 use alloy::{
     network::TxSigner,
     primitives::Address,
@@ -52,7 +54,7 @@ impl TxSigner<Signature> for GenericSigner {
 }
 
 /// Configuration for the existing signers
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum SignerConfig {
@@ -67,27 +69,27 @@ pub enum SignerConfig {
 }
 
 /// Configuration for a private key signer
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PrivateKeyConfig {
     private_key: String,
 }
 
 /// Configuration for a keystore signer
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct KeystoreConfig {
     path: String,
     password: String,
 }
 
 /// Configuration for a web3 signer
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Web3Config {
     endpoint: String,
     address: Address,
 }
 
 /// Configuration for an AWS KMS signer
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AwsConfig {
     key_id: String,
     chain_id: Option<u64>,

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -7,6 +7,7 @@ use alloy::{
         Signature,
     },
 };
+use async_trait::async_trait;
 use aws_config::{BehaviorVersion, Region};
 use aws_sdk_kms::config::{Credentials, SharedCredentialsProvider};
 use serde::{Deserialize, Serialize};
@@ -18,14 +19,47 @@ use crate::{signer_v2::error::SignerError, web3_signer::Web3Signer};
 /// Error types for the signer v2 module
 pub mod error;
 
+/// Enum that contains all possible signer types
+#[derive(Debug)]
+enum Signer {
+    /// Hexadecimal private key
+    PrivateKey(PrivateKeySigner),
+    /// Web3 signer
+    Web3(Web3Signer),
+    /// AWS KMS signer
+    Aws(AwsSigner),
+}
+
+#[async_trait]
+impl TxSigner<Signature> for Signer {
+    fn address(&self) -> Address {
+        match self {
+            Signer::PrivateKey(signer) => signer.address(),
+            Signer::Web3(signer) => signer.address(),
+            Signer::Aws(signer) => signer.address(),
+        }
+    }
+
+    async fn sign_transaction(
+        &self,
+        tx: &mut dyn alloy::consensus::SignableTransaction<Signature>,
+    ) -> alloy::signers::Result<Signature> {
+        match self {
+            Signer::PrivateKey(signer) => signer.sign_transaction(tx).await,
+            Signer::Web3(signer) => signer.sign_transaction(tx).await,
+            Signer::Aws(signer) => signer.sign_transaction(tx).await,
+        }
+    }
+}
+
 /// Configuration for the existing signers
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum SignerConfig {
-    /// ECDSA hexadecimal private key
+    /// Hexadecimal private key
     PrivateKey { private_key_hex: String },
-    /// ECDSA keystore path and password
+    /// Keystore path and password
     Keystore { path: String, password: String },
     /// Web3Signer
     Web3 { endpoint: String, address: Address },
@@ -51,19 +85,19 @@ pub enum SignerConfig {
 /// * A signer that implements the [`TxSigner`] trait
 pub async fn tx_signer_from_config(
     config: SignerConfig,
-) -> Result<Box<dyn TxSigner<Signature>>, SignerError> {
+) -> Result<impl TxSigner<Signature>, SignerError> {
     match config {
-        SignerConfig::PrivateKey { private_key_hex } => {
-            Ok(Box::new(PrivateKeySigner::from_str(&private_key_hex)?))
-        }
-        SignerConfig::Keystore { path, password } => {
-            Ok(Box::new(LocalSigner::decrypt_keystore(path, password)?))
-        }
+        SignerConfig::PrivateKey { private_key_hex } => Ok(Signer::PrivateKey(
+            PrivateKeySigner::from_str(&private_key_hex)?,
+        )),
+        SignerConfig::Keystore { path, password } => Ok(Signer::PrivateKey(
+            LocalSigner::decrypt_keystore(path, password)?,
+        )),
         SignerConfig::Web3 { endpoint, address } => {
             let url: Url = endpoint
                 .parse()
                 .map_err(|_| SignerError::InvalidEndpointUrl)?;
-            Ok(Box::new(Web3Signer::new(address, url)))
+            Ok(Signer::Web3(Web3Signer::new(address, url)))
         }
         SignerConfig::Aws {
             key_id,
@@ -84,7 +118,7 @@ pub async fn tx_signer_from_config(
                 .region(Some(aws_region))
                 .build();
             let client = aws_sdk_kms::Client::new(&config);
-            Ok(Box::new(
+            Ok(Signer::Aws(
                 AwsSigner::new(client, key_id, chain_id)
                     .await
                     .map_err(|e| SignerError::AwsSignerError(Box::new(e)))?,

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -161,6 +161,8 @@ mod test {
     const KEYSTORE_PATH: &str = "mockdata/dummy.key.json";
     const KEYSTORE_PASSWORD: &str = "testpassword";
     const LOCALSTACK_PORT: u16 = 4566;
+    // Add this port to avoid conflicts with the test of the signer v1
+    const LOCALSTACK_MAPPED_PORT: u16 = 4567;
     const AWS_US_WEST_REGION: &str = "us-west-1";
     const LOCALSTACK_IMAGE_NAME: &str = "localstack/localstack";
     const LOCALSTACK_IMAGE_TAG: &str = "latest";
@@ -223,7 +225,7 @@ mod test {
         // Start the container running Localstack
         let _container = start_localstack_container().await;
 
-        let localstack_endpoint = format!("http://localhost:{}", LOCALSTACK_PORT);
+        let localstack_endpoint = format!("http://localhost:{}", LOCALSTACK_MAPPED_PORT);
         let config = get_aws_config(
             "localstack".into(),
             "localstack".into(),
@@ -307,7 +309,7 @@ mod test {
         GenericImage::new(LOCALSTACK_IMAGE_NAME, LOCALSTACK_IMAGE_TAG)
             .with_exposed_port(LOCALSTACK_PORT.tcp())
             .with_wait_for(WaitFor::message_on_stdout("Ready."))
-            .with_mapped_port(LOCALSTACK_PORT, LOCALSTACK_PORT.tcp())
+            .with_mapped_port(LOCALSTACK_MAPPED_PORT, LOCALSTACK_PORT.tcp())
             .start()
             .await
             .expect("Error starting localstack container")

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -1,0 +1,33 @@
+use alloy::primitives::Address;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum SignerConfig {
+    PrivateKey {
+        private_key_hex: String,
+    },
+
+    Keystore {
+        path: String,
+        password: String,
+    },
+
+    /// Firma vía Web3Signer (JSON-RPC a un nodo remoto).
+    Web3 {
+        /// URL del endpoint HTTP(S) donde está el Web3Signer.
+        endpoint: Url,
+        address: Address,
+    },
+
+    Aws {
+        key_id: String,
+        chain_id: Option<u64>,
+        access_key: String,
+        secret_access_key: String,
+        region: String,
+        endpoint_url: String,
+    },
+}

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -23,10 +23,9 @@ pub mod error;
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum SignerConfig {
-    /// Hexadecimal private key
+    /// ECDSA hexadecimal private key
     PrivateKey { private_key_hex: String },
-    /// Keystore path and password
-    /// Right now, only ECDSA keystore format is supported
+    /// ECDSA keystore path and password
     Keystore { path: String, password: String },
     /// Web3Signer
     Web3 { endpoint: String, address: Address },
@@ -39,13 +38,6 @@ pub enum SignerConfig {
         region: String,
         endpoint_url: String,
     },
-}
-
-pub enum BlsKeySource {
-    /// Raw private key
-    PrivateKey { private_key_hex: String },
-    /// Keystore file + password
-    Keystore { path: String, password: String },
 }
 
 /// Creates a transaction signer from a configuration
@@ -92,7 +84,11 @@ pub async fn tx_signer_from_config(
                 .region(Some(aws_region))
                 .build();
             let client = aws_sdk_kms::Client::new(&config);
-            Ok(Box::new(AwsSigner::new(client, key_id, chain_id).await?))
+            Ok(Box::new(
+                AwsSigner::new(client, key_id, chain_id)
+                    .await
+                    .map_err(|e| SignerError::AwsSignerError(Box::new(e)))?,
+            ))
         }
     }
 }

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -161,6 +161,7 @@ mod test {
     };
     use eigen_testing_utils::anvil::start_anvil_container;
     use eigen_testing_utils::test_data::TestData;
+    use std::env;
     use std::str::FromStr;
     use testcontainers::{
         core::{IntoContainerPort, WaitFor},
@@ -241,6 +242,10 @@ mod test {
     async fn test_sign_transaction_with_kms_signer() {
         // Start the container running Localstack
         let _container = start_localstack_container().await;
+
+        // Set the environment variables for the AWS credentials
+        env::set_var("AWS_ACCESS_KEY_ID", "localstack");
+        env::set_var("AWS_SECRET_ACCESS_KEY", "localstack");
 
         let localstack_endpoint = format!("http://localhost:{}", LOCALSTACK_MAPPED_PORT);
         let config = get_aws_config(

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -19,16 +19,78 @@
 //!
 //! **v1**: Returns different concrete types:
 //!
-//! ```rust,ignore
-//! let private_signer = Config::signer_from_config(config)?; // PrivateKeySigner
-//! let aws_signer = Config::aws_signer(key_id, chain_id, client).await?; // AwsSigner
+//! ```rust,no_run
+//! # use eigen_signer::signer::Config;
+//! # use alloy::network::TxSigner;
+//! # use alloy::consensus::TxLegacy;
+//! # use alloy::primitives::{bytes, hex_literal::hex, Address, U256};
+//! # const PRIVATE_KEY: &str = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
+//! # const ADDRESS: [u8; 20] = hex!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+//! # const ENDPOINT: &str = "http://localhost:8545";
+//! # #[tokio::main]
+//! # async fn main() {
+//! #     let mut tx = TxLegacy {
+//! #         to: Address::from(ADDRESS).into(),
+//! #         value: U256::from(1_000_000_000),
+//! #         gas_limit: 2_000_000,
+//! #         nonce: 0,
+//! #         gas_price: 21_000_000_000,
+//! #         input: bytes!(),
+//! #         chain_id: Some(1),
+//! #     };
+//! #
+//! // Create a signer from the private key configuration
+//! // This returns a `PrivateKeySigner`
+//! let config = Config::PrivateKey(PRIVATE_KEY.into());
+//! let private_signer = Config::signer_from_config(config).unwrap();
+//! private_signer.sign_transaction(&mut tx).await.unwrap();
+//!
+//! // Create a web3 signer from the endpoint and address
+//! // This returns a `Web3Signer`
+//! let web3_signer = Config::web3_signer(ENDPOINT.to_string(), ADDRESS.into()).unwrap();
+//! web3_signer.sign_transaction(&mut tx).await.unwrap();
+//! # }
 //! ```
 //!
 //! **v2**: Returns a unified trait object:
 //!
-//! ```rust,ignore
-//! let signer = tx_signer_from_config(any_config).await?; // impl TxSigner<Signature>
-//! signer.sign_transaction(&mut tx).await?; // Same method for all types
+//! ```rust,no_run
+//! # use eigen_signer::signer_v2::{SignerConfig, tx_signer_from_config, PrivateKeyConfig, Web3Config};
+//! # use alloy::primitives::{address, bytes, hex_literal::hex, Address, U256};
+//! # use alloy::consensus::TxLegacy;
+//! # use alloy::network::TxSigner;
+//! # const PRIVATE_KEY: &str = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
+//! # const ADDRESS: [u8; 20] = hex!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+//! # const ENDPOINT: &str = "http://localhost:8545";
+//! # #[tokio::main]
+//! # async fn main() {
+//! #    let mut tx = TxLegacy {
+//! #        to: Address::from(ADDRESS).into(),
+//! #        value: U256::from(1_000_000_000),
+//! #        gas_limit: 2_000_000,
+//! #        nonce: 0,
+//! #        gas_price: 21_000_000_000,
+//! #        input: bytes!(),
+//! #        chain_id: Some(1),
+//! #    };
+//! #
+//! // Create a signer from the private key configuration
+//! // This returns a `GenericSigner` that implements the `TxSigner` trait
+//! let private_config = SignerConfig::PrivateKey(PrivateKeyConfig {
+//!     private_key: PRIVATE_KEY.into(),
+//! });
+//! let signer = tx_signer_from_config(private_config).await.unwrap();
+//! signer.sign_transaction(&mut tx).await.unwrap();
+//!
+//! // Create a signer from the web3 configuration
+//! // This returns a `GenericSigner` that implements the `TxSigner` trait
+//! let web3_config = SignerConfig::Web3(Web3Config {
+//!     endpoint: ENDPOINT.to_string(),
+//!     address: ADDRESS.into(),
+//! });
+//! let signer = tx_signer_from_config(web3_config).await.unwrap();
+//! signer.sign_transaction(&mut tx).await.unwrap();
+//! # }
 //! ```
 //!
 //! ### Configuration System
@@ -36,18 +98,20 @@
 //! **v1**: Simple enum with tuple variants. No serialization support, so configurations must be
 //! created programmatically.
 //!
-//! ```rust,ignore
+//! ```rust
 //! pub enum Config {
-//!     PrivateKey(String),           // Raw string
-//!     Keystore(String, String),     // (path, password) tuple
+//!     PrivateKey(String),
+//!     Keystore(String, String),
 //! }
 //! ```
 //!
 //! **v2**: Structured, serializable configuration with named fields.
 //! This is useful for configuration files.
 //!
-//! ```rust,ignore
-//! #[derive(Serialize, Deserialize)]
+//! ```rust
+//! # use eigen_signer::signer_v2::{PrivateKeyConfig, KeystoreConfig, Web3Config, AwsConfig};
+//! # use serde::{Serialize, Deserialize};
+//! #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 //! pub enum SignerConfig {
 //!     PrivateKey(PrivateKeyConfig),
 //!     Keystore(KeystoreConfig),
@@ -136,38 +200,38 @@ pub enum SignerConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PrivateKeyConfig {
     /// Hexadecimal private key
-    private_key: String,
+    pub private_key: String,
 }
 
 /// Configuration for a keystore signer
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct KeystoreConfig {
     /// Path to the keystore file
-    path: String,
+    pub path: String,
     /// Password to decrypt the keystore file
-    password: String,
+    pub password: String,
 }
 
 /// Configuration for a web3 signer
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Web3Config {
     /// Endpoint URL
-    endpoint: String,
+    pub endpoint: String,
     /// Address of the signer
-    address: Address,
+    pub address: Address,
 }
 
 /// Configuration for an AWS KMS signer
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AwsConfig {
     /// Key ID
-    key_id: String,
+    pub key_id: String,
     /// Chain ID
-    chain_id: Option<u64>,
+    pub chain_id: Option<u64>,
     /// Region
-    region: String,
+    pub region: String,
     /// Endpoint URL
-    endpoint_url: String,
+    pub endpoint_url: String,
 }
 
 /// Creates a transaction signer from a configuration

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -148,7 +148,6 @@ mod test {
     use crate::signer_v2::{
         tx_signer_from_config, AwsConfig, KeystoreConfig, PrivateKeyConfig, Web3Config,
     };
-    use serde_json;
 
     use super::SignerConfig;
     use alloy::consensus::{SignableTransaction, TxLegacy};
@@ -333,23 +332,32 @@ mod test {
         let original = PrivateKeyConfig {
             private_key: "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7".into(),
         };
+        let toml_str = toml::to_string(&original).unwrap();
+        let parsed: PrivateKeyConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed, original);
 
-        let json_str = serde_json::to_string(&original).unwrap();
-
-        let parsed: PrivateKeyConfig = serde_json::from_str(&json_str).unwrap();
+        let toml_str = r#"
+            private_key = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7"
+        "#;
+        let parsed: PrivateKeyConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(parsed, original);
     }
 
     #[test]
     fn test_keystore_config_serialization() {
         let original = KeystoreConfig {
-            path: "mockdata/dummy.key.json".into(),
+            path: "ecdsa.key.json".into(),
             password: "testpassword".into(),
         };
+        let toml_str = toml::to_string(&original).unwrap();
+        let parsed: KeystoreConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed, original);
 
-        let json_str = serde_json::to_string(&original).unwrap();
-
-        let parsed: KeystoreConfig = serde_json::from_str(&json_str).unwrap();
+        let toml_str = r#"
+            path ="ecdsa.key.json"
+            password = "testpassword"
+        "#;
+        let parsed: KeystoreConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(parsed, original);
     }
 
@@ -359,10 +367,15 @@ mod test {
             endpoint: "http://localhost:8545".into(),
             address: Address::from(hex!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045")),
         };
+        let toml_str = toml::to_string(&original).unwrap();
+        let parsed: Web3Config = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed, original);
 
-        let json_str = serde_json::to_string(&original).unwrap();
-
-        let parsed: Web3Config = serde_json::from_str(&json_str).unwrap();
+        let toml_str = r#"
+            endpoint = "http://localhost:8545"
+            address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        "#;
+        let parsed: Web3Config = toml::from_str(toml_str).unwrap();
         assert_eq!(parsed, original);
     }
 
@@ -374,10 +387,17 @@ mod test {
             region: "us-west-1".into(),
             endpoint_url: "http://localhost:4566".into(),
         };
+        let toml_str = toml::to_string(&original).unwrap();
+        let parsed: AwsConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed, original);
 
-        let json_str = serde_json::to_string(&original).unwrap();
-
-        let parsed: AwsConfig = serde_json::from_str(&json_str).unwrap();
+        let toml_str = r#"
+            key_id = "1234abcd-12ab-34cd-56ef-1234567890ab"
+            chain_id = 1
+            region = "us-west-1"
+            endpoint_url = "http://localhost:4566"
+        "#;
+        let parsed: AwsConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(parsed, original);
     }
 

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -71,29 +71,38 @@ pub enum SignerConfig {
 /// Configuration for a private key signer
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PrivateKeyConfig {
+    /// Hexadecimal private key
     private_key: String,
 }
 
 /// Configuration for a keystore signer
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct KeystoreConfig {
+    /// Path to the keystore file
     path: String,
+    /// Password to decrypt the keystore file
     password: String,
 }
 
 /// Configuration for a web3 signer
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Web3Config {
+    /// Endpoint URL
     endpoint: String,
+    /// Address of the signer
     address: Address,
 }
 
 /// Configuration for an AWS KMS signer
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AwsConfig {
+    /// Key ID
     key_id: String,
+    /// Chain ID
     chain_id: Option<u64>,
+    /// Region
     region: String,
+    /// Endpoint URL
     endpoint_url: String,
 }
 

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -1,6 +1,18 @@
-use alloy::primitives::Address;
+use alloy::{
+    network::TxSigner,
+    primitives::Address,
+    signers::{
+        aws::AwsSigner,
+        local::{LocalSigner, PrivateKeySigner},
+        Signature,
+    },
+};
+use aws_config::BehaviorVersion;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 use url::Url;
+
+use crate::web3_signer::Web3Signer;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -14,20 +26,34 @@ pub enum SignerConfig {
         path: String,
         password: String,
     },
-
-    /// Firma vía Web3Signer (JSON-RPC a un nodo remoto).
     Web3 {
-        /// URL del endpoint HTTP(S) donde está el Web3Signer.
-        endpoint: Url,
+        endpoint: String,
         address: Address,
     },
-
     Aws {
         key_id: String,
         chain_id: Option<u64>,
-        access_key: String,
-        secret_access_key: String,
-        region: String,
-        endpoint_url: String,
     },
+}
+
+pub async fn tx_signer_from_config(config: SignerConfig) -> impl TxSigner<Signature> {
+    match config {
+        SignerConfig::PrivateKey { private_key_hex } => {
+            PrivateKeySigner::from_str(&private_key_hex).unwrap()
+        }
+        SignerConfig::Keystore { path, password } => {
+            // Support for ECDSA
+            LocalSigner::decrypt_keystore(path, password).unwrap()
+        }
+        SignerConfig::Web3 { endpoint, address } => {
+            let url: Url = endpoint.parse().unwrap();
+            Web3Signer::new(address, url)
+        }
+        SignerConfig::Aws { key_id, chain_id } => {
+            // Review default values
+            let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+            let client = aws_sdk_kms::Client::new(&config);
+            AwsSigner::new(client, key_id, chain_id)
+        }
+    }
 }

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -205,18 +205,25 @@ pub enum SignerConfig {
     ///
     /// Delegates transaction signing to an external signing service. The endpoint
     /// URL must be a valid JSON-RPC endpoint.
+    ///
     Web3(Web3Config),
     /// AWS KMS signer
     ///
     /// Uses an AWS KMS asymmetric key (curve `secp256k1`) to sign transactions.
     /// The private key material never leaves AWS's Hardware Security Module.
     ///
-    /// The AWS credentials will be loaded from the environment variables.
+    /// <div class="warning">
+    /// This signer requires AWS credentials to be set via environment variables.
+    /// See the <a href="https://docs.aws.amazon.com/sdkref/latest/guide/environment-variables.html">AWS documentation</a>
+    /// for details and the <a href="https://docs.aws.amazon.com/sdkref/latest/guide/settings-reference.html#EVarSettings">AWS Settings Reference</a>
+    /// for a full list of available environment variables.
     ///
+    /// To configure your shell, run:
     /// ```bash
     /// export AWS_ACCESS_KEY_ID=your-access-key-id
     /// export AWS_SECRET_ACCESS_KEY=your-secret-access-key
     /// ```
+    /// </div>
     Aws(AwsConfig),
 }
 
@@ -282,14 +289,23 @@ pub struct Web3Config {
     pub address: Address,
 }
 
-/// Configuration for an AWS KMS signer
+/// AWS KMS signer
 ///
-/// The AWS credentials will be loaded from the environment variables.
+/// Uses an AWS KMS asymmetric key (curve `secp256k1`) to sign transactions.
+/// The private key material never leaves AWS's Hardware Security Module.
 ///
+/// <div class="warning">
+/// This signer requires AWS credentials to be set via environment variables.
+/// See the <a href="https://docs.aws.amazon.com/sdkref/latest/guide/environment-variables.html">AWS documentation</a>
+/// for details and the <a href="https://docs.aws.amazon.com/sdkref/latest/guide/settings-reference.html#EVarSettings">AWS Settings Reference</a>
+/// for a full list of available environment variables.
+///
+/// To configure your shell, run:
 /// ```bash
 /// export AWS_ACCESS_KEY_ID=your-access-key-id
 /// export AWS_SECRET_ACCESS_KEY=your-secret-access-key
 /// ```
+/// </div>
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AwsConfig {
     /// Key ID

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -107,7 +107,6 @@ pub async fn tx_signer_from_config(
             region,
             endpoint_url,
         } => {
-            // Review default values
             let creds = Credentials::new(access_key, secret_access_key, None, None, "Static");
             let aws_region = Region::new(region);
             let config = aws_config::load_defaults(BehaviorVersion::latest())

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -12,48 +12,51 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use url::Url;
 
-use crate::web3_signer::Web3Signer;
+use crate::{signer_v2::error::SignerError, web3_signer::Web3Signer};
 
+/// Error types for the signer v2 module
+pub mod error;
+
+/// Configuration for the existing signers
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum SignerConfig {
-    PrivateKey {
-        private_key_hex: String,
-    },
-
-    Keystore {
-        path: String,
-        password: String,
-    },
-    Web3 {
-        endpoint: String,
-        address: Address,
-    },
+    /// Hexadecimal private key
+    PrivateKey { private_key_hex: String },
+    /// Keystore path and password
+    /// Right now, only ECDSA keystore format is supported
+    Keystore { path: String, password: String },
+    /// Web3Signer endpoint and address
+    Web3 { endpoint: String, address: Address },
+    /// AWS KMS key ID and chain ID
     Aws {
         key_id: String,
         chain_id: Option<u64>,
     },
 }
 
-pub async fn tx_signer_from_config(config: SignerConfig) -> impl TxSigner<Signature> {
+/// Creates a transaction signer from a configuration
+pub async fn tx_signer_from_config(
+    config: SignerConfig,
+) -> Result<Box<dyn TxSigner<Signature>>, SignerError> {
     match config {
         SignerConfig::PrivateKey { private_key_hex } => {
-            PrivateKeySigner::from_str(&private_key_hex).unwrap()
+            Ok(Box::new(PrivateKeySigner::from_str(&private_key_hex)?))
         }
         SignerConfig::Keystore { path, password } => {
             // Support for ECDSA
-            LocalSigner::decrypt_keystore(path, password).unwrap()
+            Ok(Box::new(LocalSigner::decrypt_keystore(path, password)?))
         }
         SignerConfig::Web3 { endpoint, address } => {
             let url: Url = endpoint.parse().unwrap();
-            Web3Signer::new(address, url)
+            Ok(Box::new(Web3Signer::new(address, url)))
         }
         SignerConfig::Aws { key_id, chain_id } => {
             // Review default values
             let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
             let client = aws_sdk_kms::Client::new(&config);
-            AwsSigner::new(client, key_id, chain_id)
+            Ok(Box::new(AwsSigner::new(client, key_id, chain_id).await?))
         }
     }
 }

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -8,8 +8,7 @@ use alloy::{
     },
 };
 use async_trait::async_trait;
-use aws_config::{BehaviorVersion, Region};
-use aws_sdk_kms::config::{Credentials, SharedCredentialsProvider};
+use aws_config::Region;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use url::Url;
@@ -21,7 +20,7 @@ pub mod error;
 
 /// Enum that contains all possible signer types
 #[derive(Debug)]
-enum Signer {
+enum GenericSigner {
     /// Hexadecimal private key
     PrivateKey(PrivateKeySigner),
     /// Web3 signer
@@ -31,12 +30,12 @@ enum Signer {
 }
 
 #[async_trait]
-impl TxSigner<Signature> for Signer {
+impl TxSigner<Signature> for GenericSigner {
     fn address(&self) -> Address {
         match self {
-            Signer::PrivateKey(signer) => signer.address(),
-            Signer::Web3(signer) => signer.address(),
-            Signer::Aws(signer) => signer.address(),
+            GenericSigner::PrivateKey(signer) => signer.address(),
+            GenericSigner::Web3(signer) => signer.address(),
+            GenericSigner::Aws(signer) => signer.address(),
         }
     }
 
@@ -45,9 +44,9 @@ impl TxSigner<Signature> for Signer {
         tx: &mut dyn alloy::consensus::SignableTransaction<Signature>,
     ) -> alloy::signers::Result<Signature> {
         match self {
-            Signer::PrivateKey(signer) => signer.sign_transaction(tx).await,
-            Signer::Web3(signer) => signer.sign_transaction(tx).await,
-            Signer::Aws(signer) => signer.sign_transaction(tx).await,
+            GenericSigner::PrivateKey(signer) => signer.sign_transaction(tx).await,
+            GenericSigner::Web3(signer) => signer.sign_transaction(tx).await,
+            GenericSigner::Aws(signer) => signer.sign_transaction(tx).await,
         }
     }
 }
@@ -58,20 +57,42 @@ impl TxSigner<Signature> for Signer {
 #[non_exhaustive]
 pub enum SignerConfig {
     /// Hexadecimal private key
-    PrivateKey { private_key_hex: String },
-    /// Keystore path and password
-    Keystore { path: String, password: String },
-    /// Web3Signer
-    Web3 { endpoint: String, address: Address },
+    PrivateKey(PrivateKeyConfig),
+    /// Keystore
+    Keystore(KeystoreConfig),
+    /// Web3
+    Web3(Web3Config),
     /// AWS KMS
-    Aws {
-        key_id: String,
-        chain_id: Option<u64>,
-        access_key: String,
-        secret_access_key: String,
-        region: String,
-        endpoint_url: String,
-    },
+    Aws(AwsConfig),
+}
+
+/// Configuration for a private key signer
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrivateKeyConfig {
+    private_key: String,
+}
+
+/// Configuration for a keystore signer
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeystoreConfig {
+    path: String,
+    password: String,
+}
+
+/// Configuration for a web3 signer
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Web3Config {
+    endpoint: String,
+    address: Address,
+}
+
+/// Configuration for an AWS KMS signer
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AwsConfig {
+    key_id: String,
+    chain_id: Option<u64>,
+    region: String,
+    endpoint_url: String,
 }
 
 /// Creates a transaction signer from a configuration
@@ -87,37 +108,31 @@ pub async fn tx_signer_from_config(
     config: SignerConfig,
 ) -> Result<impl TxSigner<Signature>, SignerError> {
     match config {
-        SignerConfig::PrivateKey { private_key_hex } => Ok(Signer::PrivateKey(
-            PrivateKeySigner::from_str(&private_key_hex)?,
-        )),
-        SignerConfig::Keystore { path, password } => Ok(Signer::PrivateKey(
+        SignerConfig::PrivateKey(PrivateKeyConfig { private_key }) => Ok(
+            GenericSigner::PrivateKey(PrivateKeySigner::from_str(&private_key)?),
+        ),
+        SignerConfig::Keystore(KeystoreConfig { path, password }) => Ok(GenericSigner::PrivateKey(
             LocalSigner::decrypt_keystore(path, password)?,
         )),
-        SignerConfig::Web3 { endpoint, address } => {
+        SignerConfig::Web3(Web3Config { endpoint, address }) => {
             let url: Url = endpoint
                 .parse()
                 .map_err(|_| SignerError::InvalidEndpointUrl)?;
-            Ok(Signer::Web3(Web3Signer::new(address, url)))
+            Ok(GenericSigner::Web3(Web3Signer::new(address, url)))
         }
-        SignerConfig::Aws {
+        SignerConfig::Aws(AwsConfig {
             key_id,
             chain_id,
-            access_key,
-            secret_access_key,
             region,
             endpoint_url,
-        } => {
-            let creds = Credentials::new(access_key, secret_access_key, None, None, "Static");
-            let aws_region = Region::new(region);
-            let config = aws_config::load_defaults(BehaviorVersion::latest())
-                .await
-                .to_builder()
-                .credentials_provider(SharedCredentialsProvider::new(creds))
+        }) => {
+            let config = aws_config::from_env()
                 .endpoint_url(endpoint_url)
-                .region(Some(aws_region))
-                .build();
+                .region(Some(Region::new(region)))
+                .load()
+                .await;
             let client = aws_sdk_kms::Client::new(&config);
-            Ok(Signer::Aws(
+            Ok(GenericSigner::Aws(
                 AwsSigner::new(client, key_id, chain_id)
                     .await
                     .map_err(|e| SignerError::AwsSignerError(Box::new(e)))?,
@@ -128,7 +143,9 @@ pub async fn tx_signer_from_config(
 
 #[cfg(test)]
 mod test {
-    use crate::signer_v2::tx_signer_from_config;
+    use crate::signer_v2::{
+        tx_signer_from_config, AwsConfig, KeystoreConfig, PrivateKeyConfig, Web3Config,
+    };
 
     use super::SignerConfig;
     use alloy::consensus::{SignableTransaction, TxLegacy};
@@ -169,9 +186,9 @@ mod test {
 
     #[tokio::test]
     async fn sign_transaction_with_private_key() {
-        let config = SignerConfig::PrivateKey {
-            private_key_hex: PRIVATE_KEY.into(),
-        };
+        let config = SignerConfig::PrivateKey(PrivateKeyConfig {
+            private_key: PRIVATE_KEY.into(),
+        });
         let mut tx = TxLegacy {
             to: Address::from(ADDRESS).into(),
             value: U256::from(1_000_000_000),
@@ -196,10 +213,10 @@ mod test {
 
     #[tokio::test]
     async fn sign_transaction_with_keystore() {
-        let config = SignerConfig::Keystore {
+        let config = SignerConfig::Keystore(KeystoreConfig {
             path: KEYSTORE_PATH.into(),
             password: KEYSTORE_PASSWORD.into(),
-        };
+        });
         let mut tx = TxLegacy {
             to: Address::from(ADDRESS).into(),
             value: U256::from(1_000_000_000),
@@ -254,14 +271,12 @@ mod test {
         // Create a signer for the given key
         let key_id = key_metadata.key_id();
         let chain_id = Some(1);
-        let signer = tx_signer_from_config(SignerConfig::Aws {
+        let signer = tx_signer_from_config(SignerConfig::Aws(AwsConfig {
             key_id: key_id.into(),
             chain_id,
-            access_key: "localstack".into(),
-            secret_access_key: "localstack".into(),
             region: AWS_US_WEST_REGION.into(),
             endpoint_url: localstack_endpoint,
-        })
+        }))
         .await
         .unwrap();
 
@@ -283,7 +298,7 @@ mod test {
         let (_container, endpoint, _ws_endpoint) = start_anvil_container().await;
 
         let address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-        let signer = tx_signer_from_config(SignerConfig::Web3 { endpoint, address })
+        let signer = tx_signer_from_config(SignerConfig::Web3(Web3Config { endpoint, address }))
             .await
             .unwrap();
         let mut tx = TxLegacy {

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -186,13 +186,37 @@ impl TxSigner<Signature> for GenericSigner {
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum SignerConfig {
-    /// Hexadecimal private key
+    /// ECDSA hexadecimal private key.
+    ///
+    /// Uses a raw hexadecimal private key for transaction signing.
     PrivateKey(PrivateKeyConfig),
-    /// Keystore
+    /// Encrypted keystore file
+    ///
+    /// Uses encrypted keystore files following the [Web3 Secret Storage](https://ethereum.org/es/developers/docs/data-structures-and-encoding/web3-secret-storage) standard.
+    /// The private key is encrypted with a password and stored in a JSON file.
+    ///
+    /// To create a keystore, you can use the `eigen-cli` tool.
+    ///
+    /// ```bash
+    /// cargo run --package eigen-cli -- egnkey generate --key-type ecdsa
+    /// ```
     Keystore(KeystoreConfig),
-    /// Web3
+    /// Web3 signer
+    ///
+    /// Delegates transaction signing to an external signing service. The endpoint
+    /// URL must be a valid JSON-RPC endpoint.
     Web3(Web3Config),
-    /// AWS KMS
+    /// AWS KMS signer
+    ///
+    /// Uses an AWS KMS asymmetric key (curve `secp256k1`) to sign transactions.
+    /// The private key material never leaves AWS's Hardware Security Module.
+    ///
+    /// The AWS credentials will be loaded from the environment variables.
+    ///
+    /// ```bash
+    /// export AWS_ACCESS_KEY_ID=your-access-key-id
+    /// export AWS_SECRET_ACCESS_KEY=your-secret-access-key
+    /// ```
     Aws(AwsConfig),
 }
 
@@ -232,6 +256,15 @@ pub struct PrivateKeyConfig {
 }
 
 /// Configuration for a keystore signer
+///
+/// This must be a file in the [Web3 Secret Storage](https://ethereum.org/es/developers/docs/data-structures-and-encoding/web3-secret-storage)
+/// format.
+///
+/// To create a keystore, you can use the `eigen-cli` tool.
+///
+/// ```bash
+/// cargo run --package eigen-cli -- egnkey generate --key-type ecdsa
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct KeystoreConfig {
     /// Path to the keystore file
@@ -250,6 +283,13 @@ pub struct Web3Config {
 }
 
 /// Configuration for an AWS KMS signer
+///
+/// The AWS credentials will be loaded from the environment variables.
+///
+/// ```bash
+/// export AWS_ACCESS_KEY_ID=your-access-key-id
+/// export AWS_SECRET_ACCESS_KEY=your-secret-access-key
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AwsConfig {
     /// Key ID

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -148,6 +148,7 @@ mod test {
     use crate::signer_v2::{
         tx_signer_from_config, AwsConfig, KeystoreConfig, PrivateKeyConfig, Web3Config,
     };
+    use serde_json;
 
     use super::SignerConfig;
     use alloy::consensus::{SignableTransaction, TxLegacy};
@@ -325,6 +326,59 @@ mod test {
         let expected_signature = expected_signer.sign_transaction_sync(&mut tx).unwrap();
 
         assert_eq!(signature, expected_signature);
+    }
+
+    #[test]
+    fn test_private_key_config_serialization() {
+        let original = PrivateKeyConfig {
+            private_key: "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7".into(),
+        };
+
+        let json_str = serde_json::to_string(&original).unwrap();
+
+        let parsed: PrivateKeyConfig = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn test_keystore_config_serialization() {
+        let original = KeystoreConfig {
+            path: "mockdata/dummy.key.json".into(),
+            password: "testpassword".into(),
+        };
+
+        let json_str = serde_json::to_string(&original).unwrap();
+
+        let parsed: KeystoreConfig = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn test_web3_config_serialization() {
+        let original = Web3Config {
+            endpoint: "http://localhost:8545".into(),
+            address: Address::from(hex!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045")),
+        };
+
+        let json_str = serde_json::to_string(&original).unwrap();
+
+        let parsed: Web3Config = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn test_aws_config_serialization() {
+        let original = AwsConfig {
+            key_id: "1234abcd-12ab-34cd-56ef-1234567890ab".into(),
+            chain_id: Some(1),
+            region: "us-west-1".into(),
+            endpoint_url: "http://localhost:4566".into(),
+        };
+
+        let json_str = serde_json::to_string(&original).unwrap();
+
+        let parsed: AwsConfig = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed, original);
     }
 
     async fn start_localstack_container() -> ContainerAsync<GenericImage> {

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -186,7 +186,7 @@ impl TxSigner<Signature> for GenericSigner {
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum SignerConfig {
-    /// ECDSA hexadecimal private key.
+    /// Hex-encoded private key plaintext.
     ///
     /// Uses a raw hexadecimal private key for transaction signing.
     PrivateKey(PrivateKeyConfig),

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -7,7 +7,8 @@ use alloy::{
         Signature,
     },
 };
-use aws_config::BehaviorVersion;
+use aws_config::{BehaviorVersion, Region};
+use aws_sdk_kms::config::{Credentials, SharedCredentialsProvider};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use url::Url;
@@ -33,6 +34,10 @@ pub enum SignerConfig {
     Aws {
         key_id: String,
         chain_id: Option<u64>,
+        access_key: String,
+        secret_access_key: String,
+        region: String,
+        endpoint_url: String,
     },
 }
 
@@ -49,12 +54,29 @@ pub async fn tx_signer_from_config(
             Ok(Box::new(LocalSigner::decrypt_keystore(path, password)?))
         }
         SignerConfig::Web3 { endpoint, address } => {
-            let url: Url = endpoint.parse().unwrap();
+            let url: Url = endpoint
+                .parse()
+                .map_err(|_| SignerError::InvalidEndpointUrl)?;
             Ok(Box::new(Web3Signer::new(address, url)))
         }
-        SignerConfig::Aws { key_id, chain_id } => {
+        SignerConfig::Aws {
+            key_id,
+            chain_id,
+            access_key,
+            secret_access_key,
+            region,
+            endpoint_url,
+        } => {
             // Review default values
-            let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+            let creds = Credentials::new(access_key, secret_access_key, None, None, "Static");
+            let aws_region = Region::new(region);
+            let config = aws_config::load_defaults(BehaviorVersion::latest())
+                .await
+                .to_builder()
+                .credentials_provider(SharedCredentialsProvider::new(creds))
+                .endpoint_url(endpoint_url)
+                .region(Some(aws_region))
+                .build();
             let client = aws_sdk_kms::Client::new(&config);
             Ok(Box::new(AwsSigner::new(client, key_id, chain_id).await?))
         }

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -1,4 +1,68 @@
-//! Signer v2 module
+//! Signer v2
+//!
+//! This module provides a simple and unified way to produce cryptographic signatures.
+//!
+//! ## Overview
+//!
+//! We provide a set of signers that can be used to sign transactions since they implement the
+//! [`TxSigner`] trait.
+//!
+//! * [`PrivateKeySigner`] - Signer that uses a private key.
+//! * [`Web3Signer`] - Signer that uses a Web3 endpoint.
+//! * [`AwsSigner`] - Signer that uses AWS KMS.
+//!
+//! To create a signer, you can use the [`tx_signer_from_config`] function.
+//!
+//! ## Differences from Signer v1
+//!
+//! ### Unified Interface
+//!
+//! **v1**: Returns different concrete types:
+//!
+//! ```rust,ignore
+//! let private_signer = Config::signer_from_config(config)?; // PrivateKeySigner
+//! let aws_signer = Config::aws_signer(key_id, chain_id, client).await?; // AwsSigner
+//! ```
+//!
+//! **v2**: Returns a unified trait object:
+//!
+//! ```rust,ignore
+//! let signer = tx_signer_from_config(any_config).await?; // impl TxSigner<Signature>
+//! signer.sign_transaction(&mut tx).await?; // Same method for all types
+//! ```
+//!
+//! ### Configuration System
+//!
+//! **v1**: Simple enum with tuple variants. No serialization support, so configurations must be
+//! created programmatically.
+//!
+//! ```rust,ignore
+//! pub enum Config {
+//!     PrivateKey(String),           // Raw string
+//!     Keystore(String, String),     // (path, password) tuple
+//! }
+//! ```
+//!
+//! **v2**: Structured, serializable configuration with named fields.
+//! This is useful for configuration files.
+//!
+//! ```rust,ignore
+//! #[derive(Serialize, Deserialize)]
+//! pub enum SignerConfig {
+//!     PrivateKey(PrivateKeyConfig),
+//!     Keystore(KeystoreConfig),
+//!     Web3(Web3Config),
+//!     Aws(AwsConfig),
+//! }
+//! ```
+//!
+//! ## Examples
+//!
+//! Here are some examples of how to create a signer from a configuration file:
+//!
+//! - [Incredible Squaring](https://github.com/Layr-Labs/eigensdk-rs/blob/v2-dev-2/examples/incredible-squaring/src/config/squaring-operator.toml)
+//! - [Incredible Dot Product](https://github.com/Layr-Labs/eigensdk-rs/blob/v2-dev-2/examples/incredible-dot-product/src/config/dot-operator.toml)
+//! - [Awesome Vault Service](https://github.com/Layr-Labs/eigensdk-rs/blob/v2-dev-2/examples/awesome-vault-service/src/config/awesome-operator.toml)
 
 use alloy::{
     network::TxSigner,

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -82,3 +82,220 @@ pub async fn tx_signer_from_config(
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::signer_v2::tx_signer_from_config;
+
+    use super::SignerConfig;
+    use alloy::consensus::{SignableTransaction, TxLegacy};
+    use alloy::network::{TxSigner, TxSignerSync};
+    use alloy::primitives::PrimitiveSignature;
+    use alloy::primitives::{address, bytes, hex_literal::hex, keccak256, Address, U256};
+    use alloy::signers::local::PrivateKeySigner;
+    use aws_config::{BehaviorVersion, Region, SdkConfig};
+    use aws_sdk_kms::{
+        self,
+        config::{Credentials, SharedCredentialsProvider},
+        types::KeyMetadata,
+    };
+    use eigen_testing_utils::anvil::start_anvil_container;
+    use eigen_testing_utils::test_data::TestData;
+    use std::str::FromStr;
+    use testcontainers::{
+        core::{IntoContainerPort, WaitFor},
+        runners::AsyncRunner,
+        ContainerAsync, GenericImage, ImageExt,
+    };
+    use tokio;
+
+    const PRIVATE_KEY: &str = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7";
+    const ADDRESS: [u8; 20] = hex!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+    const SIGNATURE_R: &str =
+        "99963972037857174861280476053118856715670512199525969754644366601434507134123";
+    const SIGNATURE_S: &str =
+        "54587766196536123534774489028213321677166972433316011091332824361042811624091";
+    const KEYSTORE_PATH: &str = "mockdata/dummy.key.json";
+    const KEYSTORE_PASSWORD: &str = "testpassword";
+    const LOCALSTACK_PORT: u16 = 4566;
+    const AWS_US_WEST_REGION: &str = "us-west-1";
+    const LOCALSTACK_IMAGE_NAME: &str = "localstack/localstack";
+    const LOCALSTACK_IMAGE_TAG: &str = "latest";
+
+    #[tokio::test]
+    async fn sign_transaction_with_private_key() {
+        let config = SignerConfig::PrivateKey {
+            private_key_hex: PRIVATE_KEY.into(),
+        };
+        let mut tx = TxLegacy {
+            to: Address::from(ADDRESS).into(),
+            value: U256::from(1_000_000_000),
+            gas_limit: 2_000_000,
+            nonce: 0,
+            gas_price: 21_000_000_000,
+            input: bytes!(),
+            chain_id: Some(1),
+        };
+
+        let signer = tx_signer_from_config(config).await.unwrap();
+
+        let signature: [u8; 65] = signer.sign_transaction(&mut tx).await.unwrap().into();
+        let sig = PrimitiveSignature::try_from(&signature[..]).unwrap();
+        let expected_signature = PrimitiveSignature::new(
+            U256::from_str(SIGNATURE_R).unwrap(),
+            U256::from_str(SIGNATURE_S).unwrap(),
+            false,
+        );
+        assert_eq!(sig, expected_signature);
+    }
+
+    #[tokio::test]
+    async fn sign_transaction_with_keystore() {
+        let config = SignerConfig::Keystore {
+            path: KEYSTORE_PATH.into(),
+            password: KEYSTORE_PASSWORD.into(),
+        };
+        let mut tx = TxLegacy {
+            to: Address::from(ADDRESS).into(),
+            value: U256::from(1_000_000_000),
+            gas_limit: 2_000_000,
+            nonce: 0,
+            gas_price: 21_000_000_000,
+            input: bytes!(),
+            chain_id: Some(1),
+        };
+
+        let private_key = hex!("7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d");
+        let expected_signer = PrivateKeySigner::from_slice(&private_key).unwrap();
+        let expected_signature = expected_signer.sign_transaction_sync(&mut tx).unwrap();
+
+        let signer = tx_signer_from_config(config).await.unwrap();
+        let signature = signer.sign_transaction(&mut tx).await.unwrap();
+
+        assert_eq!(signature, expected_signature);
+    }
+
+    #[tokio::test]
+    async fn test_sign_transaction_with_kms_signer() {
+        // Start the container running Localstack
+        let _container = start_localstack_container().await;
+
+        let localstack_endpoint = format!("http://localhost:{}", LOCALSTACK_PORT);
+        let config = get_aws_config(
+            "localstack".into(),
+            "localstack".into(),
+            Region::from_static(AWS_US_WEST_REGION),
+            localstack_endpoint.clone(),
+        )
+        .await;
+
+        let default_tx = TxLegacy {
+            to: address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").into(),
+            value: U256::from(1_000_000_000),
+            gas_limit: 2_000_000,
+            nonce: 0,
+            gas_price: 21_000_000_000,
+            input: bytes!(),
+            chain_id: Some(1),
+        };
+        let mut test_data: TestData<TxLegacy> = TestData::new(default_tx);
+
+        // Create an AWS KMS Client
+        let client = aws_sdk_kms::Client::new(&config);
+
+        // Create a key
+        let key_metadata = create_kms_key(&client).await;
+
+        // Create a signer for the given key
+        let key_id = key_metadata.key_id();
+        let chain_id = Some(1);
+        let signer = tx_signer_from_config(SignerConfig::Aws {
+            key_id: key_id.into(),
+            chain_id,
+            access_key: "localstack".into(),
+            secret_access_key: "localstack".into(),
+            region: AWS_US_WEST_REGION.into(),
+            endpoint_url: localstack_endpoint,
+        })
+        .await
+        .unwrap();
+
+        // Sign the transaction
+        let signature = signer.sign_transaction(&mut test_data.input).await.unwrap();
+
+        // Recover the address
+        let mut encoded_tx = Vec::new();
+        test_data.input.encode_for_signing(&mut encoded_tx);
+        let prehash = keccak256(encoded_tx);
+        let recovered_address = signature.recover_address_from_prehash(&prehash).unwrap();
+
+        // Check that the recovered addresses are the same
+        assert_eq!(signer.address(), recovered_address);
+    }
+
+    #[tokio::test]
+    async fn test_sign_legacy_transaction_with_web3_signer() {
+        let (_container, endpoint, _ws_endpoint) = start_anvil_container().await;
+
+        let address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+        let signer = tx_signer_from_config(SignerConfig::Web3 { endpoint, address })
+            .await
+            .unwrap();
+        let mut tx = TxLegacy {
+            to: address!("a0Ee7A142d267C1f36714E4a8F75612F20a79720").into(),
+            value: U256::from(1_000_000_000),
+            gas_limit: 0x76c0,
+            gas_price: 21_000_000_000,
+            nonce: 0,
+            input: bytes!(),
+            chain_id: Some(31337),
+        };
+
+        let signature = signer.sign_transaction(&mut tx).await.unwrap();
+
+        let private_key_hex = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+        let expected_signer = PrivateKeySigner::from_str(private_key_hex).unwrap();
+        let expected_signature = expected_signer.sign_transaction_sync(&mut tx).unwrap();
+
+        assert_eq!(signature, expected_signature);
+    }
+
+    async fn start_localstack_container() -> ContainerAsync<GenericImage> {
+        GenericImage::new(LOCALSTACK_IMAGE_NAME, LOCALSTACK_IMAGE_TAG)
+            .with_exposed_port(LOCALSTACK_PORT.tcp())
+            .with_wait_for(WaitFor::message_on_stdout("Ready."))
+            .with_mapped_port(LOCALSTACK_PORT, LOCALSTACK_PORT.tcp())
+            .start()
+            .await
+            .expect("Error starting localstack container")
+    }
+
+    async fn create_kms_key(client: &aws_sdk_kms::Client) -> KeyMetadata {
+        client
+            .create_key()
+            .key_spec(aws_sdk_kms::types::KeySpec::EccSecgP256K1)
+            .key_usage(aws_sdk_kms::types::KeyUsageType::SignVerify)
+            .send()
+            .await
+            .unwrap()
+            .key_metadata()
+            .unwrap()
+            .clone()
+    }
+
+    async fn get_aws_config(
+        access_key: String,
+        secret_access_key: String,
+        region: Region,
+        endpoint_url: String,
+    ) -> SdkConfig {
+        let creds = Credentials::new(access_key, secret_access_key, None, None, "Static");
+        aws_config::load_defaults(BehaviorVersion::latest())
+            .await
+            .to_builder()
+            .credentials_provider(SharedCredentialsProvider::new(creds))
+            .endpoint_url(endpoint_url)
+            .region(Some(region.clone()))
+            .build()
+    }
+}

--- a/crates/signer/src/signer_v2/mod.rs
+++ b/crates/signer/src/signer_v2/mod.rs
@@ -76,19 +76,19 @@
 //! #
 //! // Create a signer from the private key configuration
 //! // This returns a `GenericSigner` that implements the `TxSigner` trait
-//! let private_config = SignerConfig::PrivateKey(PrivateKeyConfig {
+//! let private_config = PrivateKeyConfig {
 //!     private_key: PRIVATE_KEY.into(),
-//! });
-//! let signer = tx_signer_from_config(private_config).await.unwrap();
+//! };
+//! let signer = tx_signer_from_config(private_config.into()).await.unwrap();
 //! signer.sign_transaction(&mut tx).await.unwrap();
 //!
 //! // Create a signer from the web3 configuration
 //! // This returns a `GenericSigner` that implements the `TxSigner` trait
-//! let web3_config = SignerConfig::Web3(Web3Config {
+//! let web3_config = Web3Config {
 //!     endpoint: ENDPOINT.to_string(),
 //!     address: ADDRESS.into(),
-//! });
-//! let signer = tx_signer_from_config(web3_config).await.unwrap();
+//! };
+//! let signer = tx_signer_from_config(web3_config.into()).await.unwrap();
 //! signer.sign_transaction(&mut tx).await.unwrap();
 //! # }
 //! ```
@@ -196,6 +196,34 @@ pub enum SignerConfig {
     Aws(AwsConfig),
 }
 
+impl From<PrivateKeyConfig> for SignerConfig {
+    /// Convert a [`PrivateKeyConfig`] into a [`SignerConfig`]
+    fn from(config: PrivateKeyConfig) -> Self {
+        SignerConfig::PrivateKey(config)
+    }
+}
+
+impl From<Web3Config> for SignerConfig {
+    /// Convert a [`Web3Config`] into a [`SignerConfig`]
+    fn from(config: Web3Config) -> Self {
+        SignerConfig::Web3(config)
+    }
+}
+
+impl From<KeystoreConfig> for SignerConfig {
+    /// Convert a [`KeystoreConfig`] into a [`SignerConfig`]
+    fn from(config: KeystoreConfig) -> Self {
+        SignerConfig::Keystore(config)
+    }
+}
+
+impl From<AwsConfig> for SignerConfig {
+    /// Convert a [`AwsConfig`] into a [`SignerConfig`]
+    fn from(config: AwsConfig) -> Self {
+        SignerConfig::Aws(config)
+    }
+}
+
 /// Configuration for a private key signer
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PrivateKeyConfig {
@@ -286,7 +314,6 @@ mod test {
         tx_signer_from_config, AwsConfig, KeystoreConfig, PrivateKeyConfig, Web3Config,
     };
 
-    use super::SignerConfig;
     use alloy::consensus::{SignableTransaction, TxLegacy};
     use alloy::network::{TxSigner, TxSignerSync};
     use alloy::primitives::PrimitiveSignature;
@@ -326,9 +353,9 @@ mod test {
 
     #[tokio::test]
     async fn sign_transaction_with_private_key() {
-        let config = SignerConfig::PrivateKey(PrivateKeyConfig {
+        let config = PrivateKeyConfig {
             private_key: PRIVATE_KEY.into(),
-        });
+        };
         let mut tx = TxLegacy {
             to: Address::from(ADDRESS).into(),
             value: U256::from(1_000_000_000),
@@ -339,7 +366,7 @@ mod test {
             chain_id: Some(1),
         };
 
-        let signer = tx_signer_from_config(config).await.unwrap();
+        let signer = tx_signer_from_config(config.into()).await.unwrap();
 
         let signature: [u8; 65] = signer.sign_transaction(&mut tx).await.unwrap().into();
         let sig = PrimitiveSignature::try_from(&signature[..]).unwrap();
@@ -353,10 +380,10 @@ mod test {
 
     #[tokio::test]
     async fn sign_transaction_with_keystore() {
-        let config = SignerConfig::Keystore(KeystoreConfig {
+        let config = KeystoreConfig {
             path: KEYSTORE_PATH.into(),
             password: KEYSTORE_PASSWORD.into(),
-        });
+        };
         let mut tx = TxLegacy {
             to: Address::from(ADDRESS).into(),
             value: U256::from(1_000_000_000),
@@ -371,7 +398,7 @@ mod test {
         let expected_signer = PrivateKeySigner::from_slice(&private_key).unwrap();
         let expected_signature = expected_signer.sign_transaction_sync(&mut tx).unwrap();
 
-        let signer = tx_signer_from_config(config).await.unwrap();
+        let signer = tx_signer_from_config(config.into()).await.unwrap();
         let signature = signer.sign_transaction(&mut tx).await.unwrap();
 
         assert_eq!(signature, expected_signature);
@@ -415,14 +442,13 @@ mod test {
         // Create a signer for the given key
         let key_id = key_metadata.key_id();
         let chain_id = Some(1);
-        let signer = tx_signer_from_config(SignerConfig::Aws(AwsConfig {
+        let aws_config = AwsConfig {
             key_id: key_id.into(),
             chain_id,
             region: AWS_US_WEST_REGION.into(),
             endpoint_url: localstack_endpoint,
-        }))
-        .await
-        .unwrap();
+        };
+        let signer = tx_signer_from_config(aws_config.into()).await.unwrap();
 
         // Sign the transaction
         let signature = signer.sign_transaction(&mut test_data.input).await.unwrap();
@@ -442,9 +468,11 @@ mod test {
         let (_container, endpoint, _ws_endpoint) = start_anvil_container().await;
 
         let address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-        let signer = tx_signer_from_config(SignerConfig::Web3(Web3Config { endpoint, address }))
-            .await
-            .unwrap();
+        let web3_config = Web3Config {
+            endpoint: endpoint.clone(),
+            address,
+        };
+        let signer = tx_signer_from_config(web3_config.into()).await.unwrap();
         let mut tx = TxLegacy {
             to: address!("a0Ee7A142d267C1f36714E4a8F75612F20a79720").into(),
             value: U256::from(1_000_000_000),


### PR DESCRIPTION
### What Changed?
This PR introduces a new signer, providing a improved interface and support for additional signing types.
- ECDSA (key | keystore)
- AWS KMS
- Web3Signer

The tests were copied from `signer.rs`. I also added more tests to check the serialization of the data.

To check the docs, run:
```bash
cargo doc --package eigen-signer --open
```

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
