### PR TITLE
refactor(v2): remove `operator_name` from operator struct

### DIFF
--- a/crates/operator/src/config.rs
+++ b/crates/operator/src/config.rs
@@ -10,9 +10,6 @@ pub struct OperatorConfig {
     pub bls_signer: BlsSignerConfig,
     /// Address of the operator
     pub operator_address: Address,
-    /// Name of the operator
-    /// This is used for logging and debugging purposes.
-    pub operator_name: String,
     /// Ethereum WebSocket RPC URL
     pub ws_rpc_url: String,
     /// Ethereum HTTP RPC URL

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -233,7 +233,7 @@ impl<RP> Operator<RP> {
             // Check if a registration config was provided.
             let Some(registration_config) = config.registration else {
                 error!(
-                    "Operator {operator_address} not registered and no registration config was provided"
+                    "Operator {operator_address:#x} not registered and no registration config was provided"
                 );
                 return Err(OperatorError::RegistrationError(
                     OperatorRegistrationError::RegistrationConfigMissing,
@@ -241,7 +241,7 @@ impl<RP> Operator<RP> {
             };
 
             register_operator(registration_config, http_rpc_url, bls_key_pair.clone()).await?;
-            info!("Operator {} registered successfully", operator_address);
+            info!("Operator {operator_address:#x} registered successfully");
         }
 
         let client_aggregator = ClientAggregator::new(aggregator_ip_port).await?;

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -60,7 +60,6 @@
 //!        The output will be a `bls.key.json` file. Please refer to the `eigen-cli` crate for more information.
 //!
 //!      - `operator_address`: The address of the operator
-//!      - `operator_name`: The name of the operator
 //!      - `ws_rpc_url`: The WebSocket RPC URL of the Ethereum node
 //!      - `http_rpc_url`: The HTTP RPC URL of the Ethereum node
 //!      - `registry_coordinator_address`: The address of the registry coordinator
@@ -176,7 +175,6 @@ pub mod registration;
 #[derive(Debug)]
 pub struct Operator<RP> {
     operator_id: OperatorId,
-    operator_name: String,
     client_aggregator: ClientAggregator,
     ws_rpc_url: String,
     key_pair: BlsKeyPair,
@@ -208,7 +206,6 @@ impl<RP> Operator<RP> {
         let config::OperatorConfig {
             bls_signer,
             operator_address,
-            operator_name,
             ws_rpc_url,
             http_rpc_url,
             registry_coordinator_address,
@@ -236,7 +233,7 @@ impl<RP> Operator<RP> {
             // Check if a registration config was provided.
             let Some(registration_config) = config.registration else {
                 error!(
-                    "Operator {operator_name} not registered and no registration config was provided"
+                    "Operator {operator_address} not registered and no registration config was provided"
                 );
                 return Err(OperatorError::RegistrationError(
                     OperatorRegistrationError::RegistrationConfigMissing,
@@ -244,7 +241,7 @@ impl<RP> Operator<RP> {
             };
 
             register_operator(registration_config, http_rpc_url, bls_key_pair.clone()).await?;
-            info!("Operator {} registered successfully", operator_name);
+            info!("Operator {} registered successfully", operator_address);
         }
 
         let client_aggregator = ClientAggregator::new(aggregator_ip_port).await?;
@@ -267,7 +264,6 @@ impl<RP> Operator<RP> {
 
         Ok(Self {
             operator_id,
-            operator_name: operator_name.to_string(),
             ws_rpc_url: ws_rpc_url.to_string(),
             client_aggregator: client_aggregator.clone(),
             key_pair: bls_key_pair,
@@ -313,10 +309,7 @@ impl<RP> Operator<RP> {
         while let Some(log) = stream.next().await {
             let (task_index, task) = decode_new_task::<TM::Input>(&log)?;
 
-            info!(
-                "{} picked up a new task. Task index: {}",
-                self.operator_name, task_index
-            );
+            info!("Operator picked up a new task. Task index: {task_index}");
 
             let output = self
                 .response_calculator

--- a/examples/awesome-vault-service/src/config/awesome-operator.toml
+++ b/examples/awesome-vault-service/src/config/awesome-operator.toml
@@ -1,6 +1,5 @@
 bls_signer.private_key = "1371012690269088913462269866874713266643928125698382731338806296762673180359922"
 operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-operator_name = "vault"
 http_rpc_url = "http://localhost:8545"
 ws_rpc_url = "ws://localhost:8545"
 registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"

--- a/examples/incredible-dot-product/src/config/dot-operator.toml
+++ b/examples/incredible-dot-product/src/config/dot-operator.toml
@@ -1,6 +1,5 @@
 bls_signer.private_key = "1371012690269088913462269866874713266643928125698382731338806296762673180359922"
 operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-operator_name = "dot-product"
 http_rpc_url = "http://localhost:8545"
 ws_rpc_url = "ws://localhost:8545"
 registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"

--- a/examples/incredible-squaring/src/config/squaring-operator.toml
+++ b/examples/incredible-squaring/src/config/squaring-operator.toml
@@ -1,5 +1,4 @@
 operator_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-operator_name = "squaring"
 http_rpc_url = "http://localhost:8545"
 ws_rpc_url = "ws://localhost:8545"
 registry_coordinator_address = "0x7bc06c482dead17c0e297afbc32f6e63d3846650"

--- a/tests/integration/src/incredible_squaring.rs
+++ b/tests/integration/src/incredible_squaring.rs
@@ -264,7 +264,6 @@ fn create_operator_config(http_endpoint: String, ws_endpoint: String) -> Operato
         }
         .into(),
         operator_address: Address::from_str(OPERATOR_ADDRESS).unwrap(),
-        operator_name: "squaring".to_string(),
         ws_rpc_url: ws_endpoint,
         http_rpc_url: http_endpoint,
         registry_coordinator_address: Address::from_str(REGISTRY_COORDINATOR).unwrap(),


### PR DESCRIPTION
Fixes #

### What Changed?
<!-- Describe the changes made in this pull request -->

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
