### PR TITLE
ci(v2): change rust version from stable to 1.82

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.82
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.82
         with:
             components: rustfmt, clippy
 
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.82
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.82
 
       - name: Create private key file
         run: printf "%b" "$FIREBLOCKS_PRIVATE_KEY" > fireblocks_secret.key

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,7 +24,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.82
+
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:


### PR DESCRIPTION
### What Changed?
This PR updates our CI to use Rust 1.82. Rust 1.88 was released yesterday and caused new clippy warnings/errors in the repo.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
