### PR TITLE
await erc20 approve receipt when depositing into strategy

### DIFF
--- a/crates/chainio/clients/elcontracts/src/writer.rs
+++ b/crates/chainio/clients/elcontracts/src/writer.rs
@@ -269,7 +269,7 @@ impl ELChainWriter {
 
         let contract_call = token_contract.approve(self.strategy_manager, amount);
 
-        let _approve = contract_call.send().await?;
+        let _approve = contract_call.send().await?.get_receipt().await?;
 
         let contract_strategy_manager = StrategyManager::new(self.strategy_manager, &provider);
 


### PR DESCRIPTION
### What Changed?

`deposit_erc20_into_strategy` fires off an approve then the deposit tx. In rapid order these potentially use the same nonce and cause the deposit to fail with `replacement transaction underpriced`.

```
2025-08-19T15:23:33.326818Z  INFO eigen_client_elcontracts::writer: depositing 5000000000000000000000 tokens into strategy 0x07df2e7e4bc1a49e7f16e2c83218b504c6be24f9
2025-08-19T15:23:33.906706Z ERROR newton_prover_avs::commands::register_operator: Failed to deposit into strategy: Alloy contract error: server returned an error response: error code -32000: replacement transaction underpriced
```

Await the receipt instead of firing the deposit immediately.

### Reviewer Checklist

- [ ] New features are tested and documented
- [ ] PR updates the changelog with a description of changes
- [ ] PR has one of the `changelog-X` labels (if applies)
- [ ] Code deprecates any old functionality before removing it
